### PR TITLE
dev: Configure mailhog

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,3 +37,8 @@ ENV WC_VERSION="9.3.1"
 RUN wget -O /tmp/wc.zip "https://downloads.wordpress.org/plugin/woocommerce.${WC_VERSION}.zip" \
     && unzip /tmp/wc.zip -d  /usr/src/wordpress/wp-content/plugins \
     && rm /tmp/wc.zip
+
+# MailHog
+RUN wget -O /tmp/mailhog.zip "https://downloads.wordpress.org/plugin/wp-mailhog-smtp.latest-stable.zip" \
+    && unzip /tmp/mailhog.zip -d  /usr/src/wordpress/wp-content/plugins \
+    && rm /tmp/mailhog.zip

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,6 +9,8 @@ services:
       WORDPRESS_DB_USER: root
       WORDPRESS_DB_PASSWORD: smailydev1
       WORDPRESS_DEBUG: 1
+      WORDPRESS_CONFIG_EXTRA: |
+        define( 'WP_MAILHOG_HOST', 'mailhog' );
     volumes:
     - wordpress:/var/www/html
     - ./:/var/www/html/wp-content/plugins/smaily-wordpress-plugin


### PR DESCRIPTION
Configures mailhog service to use correct hostname out of the box. Now emails sent during development will be routed to mailhog service without any additional config.