### PR TITLE
dev: Use smaily as container mount path

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -13,7 +13,7 @@ services:
         define( 'WP_MAILHOG_HOST', 'mailhog' );
     volumes:
     - wordpress:/var/www/html
-    - ./:/var/www/html/wp-content/plugins/smaily-wordpress-plugin
+    - ./:/var/www/html/wp-content/plugins/smaily
 
   db:
     image: mysql:5.7


### PR DESCRIPTION
The plugin name is Smaily and this should reflect in the folder name.