### PR TITLE
logger: Refactor logger class

### DIFF
--- a/includes/smaily-logger.class.php
+++ b/includes/smaily-logger.class.php
@@ -1,10 +1,22 @@
 <?php
+/**
+ * We use file operations outside WP to make directories in recursive mode and appending logs to file end instead of writing empty files.
+ * 
+ * phpcs:disable WordPress.WP.AlternativeFunctions.file_system_operations_mkdir, WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+ */
 
 /**
  * Logger class for smaily plugin logging
  */
 class Smaily_Logger
 {
+
+    private const LOG_DIR = SMAILY_PLUGIN_PATH . 'logs';
+
+    private const LOG_FILE = self::LOG_DIR . '/debug.log';
+
+    private const HTACCESS_FILE = self::LOG_DIR . '/.htaccess';
+
     /**
      * Log a message to the WordPress debug log.
      *
@@ -13,28 +25,31 @@ class Smaily_Logger
      */
     public static function log($message, $level = 'info')
     {
-        if (defined('WP_DEBUG') && WP_DEBUG) {
-            $log_message = sprintf('[%s] %s: %s', current_time('mysql'), strtoupper($level), $message);
-
-            if (defined('WP_DEBUG_LOG') && WP_DEBUG_LOG) {
-                $log_dir = SMAILY_PLUGIN_PATH . 'logs';
-                $log_file = $log_dir . '/debug.log';
-                $htaccess_file = $log_dir . '/.htaccess';
-
-                // Check if the logs directory exists, if not create it.
-                if (!is_dir($log_dir)) {
-                    mkdir($log_dir, 0755, true);
-
-                    // Create .htaccess file to prevent direct access.
-                    $htaccess_content = "Deny from all";
-                    file_put_contents($htaccess_file, $htaccess_content);
-                }
-
-                // Write the log message to the log file.
-                file_put_contents($log_file, $log_message . PHP_EOL, FILE_APPEND);
-            }
+        if (!defined('WP_DEBUG') || !WP_DEBUG) {
+            return;
         }
-    }
+
+        if (!defined('WP_DEBUG_LOG') || !WP_DEBUG_LOG) {
+            return;
+        }
+
+        global $wp_filesystem;
+        WP_Filesystem();
+
+        $log_message = sprintf('[%s] %s: %s', current_time('mysql'), strtoupper($level), $message);
+
+        // Check if the logs directory exists, if not create it.
+        if (!is_dir(self::LOG_DIR)) {
+            mkdir(self::LOG_DIR, 0755, true);
+
+            // Create .htaccess file to prevent direct access.
+            $htaccess_content = "Deny from all";
+            file_put_contents(self::HTACCESS_FILE, $htaccess_content);
+        }
+
+        // Write the log message to the log file.
+        file_put_contents(self::LOG_FILE, $log_message . PHP_EOL, FILE_APPEND);
+}
 
     /**
      * Log an informational message.


### PR DESCRIPTION
This PR adds phpcs ignore comments to the logger class and a notice why WP filesystem functions are not suitable for current implementation. Also refactoring log function to more standardized pattern where function short circuits when conditions are not met instead of writing nested if logic.