### PR TITLE
Fix list of autoresponders not being displayed in the block element

### DIFF
--- a/admin/smaily-admin.class.php
+++ b/admin/smaily-admin.class.php
@@ -161,7 +161,7 @@ class Smaily_Admin
             true
         );
 
-        wp_add_inline_script($this->plugin_name . '-subscription', 'const autoresponders = ' . json_encode($autoresponders), 'before');
+        wp_add_inline_script($this->plugin_name . '-subscription', "window.autoresponders = '" . wp_json_encode($autoresponders) . "';" , 'before');
     }
 
     /**


### PR DESCRIPTION
Autoresponders are loaded from `window.autoresponders` object. Instead of populating a regular const with autoresponders we need to populate the window object. This PR fixes the issue.