### PR TITLE
Refactor smaily-admin.php to WordPress coding standards

### DIFF
--- a/admin/template/smaily-admin.php
+++ b/admin/template/smaily-admin.php
@@ -10,8 +10,8 @@ if ($has_woocommerce) {
 	$cart_options            = $this->settings['woocommerce']['cart_options'];
 	$customer_sync_enabled   = (bool) (int) $this->settings['woocommerce']['customer_sync_enabled'];
 	$is_advanced             = isset($this->settings['is_advanced']) ? (bool) (int) $this->settings['is_advanced'] ?? false : false;
-	$advanced_form			 = isset($this->settings['form']) ? $this->settings['form'] ?? false : false;
-	$cart_cutoff			 = (int) $this->settings['woocommerce']['cart_cutoff'];
+	$advanced_form           = isset($this->settings['form']) ? $this->settings['form'] ?? false : false;
+	$cart_cutoff             = (int) $this->settings['woocommerce']['cart_cutoff'];
 	$cart_enabled            = (bool) (int) $this->settings['woocommerce']['enable_cart'];
 	$cart_autoresponder_name = $this->settings['woocommerce']['cart_autoresponder'];
 	$cart_autoresponder_id   = (int) $this->settings['woocommerce']['cart_autoresponder_id'];
@@ -23,14 +23,15 @@ if ($has_woocommerce) {
 	$rss_limit               = $this->settings['woocommerce']['rss_limit'];
 	$rss_order_by            = $this->settings['woocommerce']['rss_order_by'];
 	$rss_order               = $this->settings['woocommerce']['rss_order'];
-	$rss_feed_url 		     = Smaily_WC\Data_Handler::make_rss_feed_url($rss_category, $rss_limit, $rss_order_by, $rss_order);
-	$cat_args 				 = array(
+	$rss_feed_url            = Smaily_WC\Data_Handler::make_rss_feed_url($rss_category, $rss_limit, $rss_order_by, $rss_order);
+	$cat_args                = array(
+		'taxonomy' => 'product_cat',
 		'orderby'    => 'name',
 		'order'      => 'asc',
 		'hide_empty' => false,
 	);
 
-	$wc_categories_list = get_terms('product_cat', $cat_args);
+	$wc_categories_list = get_terms($cat_args);
 }
 
 ?>
@@ -40,9 +41,7 @@ if ($has_woocommerce) {
 		<span id="smaily-title">
 			<span id="capital-s">S</span>maily
 		</span>
-
-		<?php echo esc_html__('Plugin Settings', 'smaily'); ?>
-
+		<?php esc_html_e('Plugin Settings', 'smaily'); ?>
 		<div class="loader"></div>
 	</h1>
 
@@ -64,33 +63,33 @@ if ($has_woocommerce) {
 			<ul id="tabs-list">
 				<li>
 					<a href="#general" class="nav-tab nav-tab-active">
-						<?php echo esc_html__('General', 'smaily'); ?>
+						<?php esc_html_e('General', 'smaily'); ?>
 					</a>
 				</li>
 				<li>
 					<a href="#newsletter" class="nav-tab">
-						<?php echo esc_html__('Newsletter', 'smaily'); ?>
+						<?php esc_html_e('Newsletter', 'smaily'); ?>
 					</a>
 				</li>
 				<?php if ($has_woocommerce) : ?>
 					<li>
 						<a href="#customer" class="nav-tab">
-							<?php echo esc_html__('Customer Synchronization', 'smaily'); ?>
+							<?php esc_html_e('Customer Synchronization', 'smaily'); ?>
 						</a>
 					</li>
 					<li>
 						<a href="#cart" class="nav-tab">
-							<?php echo esc_html__('Abandoned Cart', 'smaily'); ?>
+							<?php esc_html_e('Abandoned Cart', 'smaily'); ?>
 						</a>
 					</li>
 					<li>
 						<a href="#checkout_subscribe" class="nav-tab">
-							<?php echo esc_html__('Checkout Opt-in', 'smaily'); ?>
+							<?php esc_html_e('Checkout Opt-in', 'smaily'); ?>
 						</a>
 					</li>
 					<li>
 						<a href="#rss" class="nav-tab">
-							<?php echo esc_html__('RSS Feed', 'smaily'); ?>
+							<?php esc_html_e('RSS Feed', 'smaily'); ?>
 						</a>
 					</li>
 				<?php endif; ?>
@@ -107,13 +106,15 @@ if ($has_woocommerce) {
 							<th scope="row"></th>
 							<td>
 								<a href="https://smaily.com/help/api/general/create-api-user/" target="_blank">
-									<?php echo esc_html__('How to create API credentials?', 'smaily'); ?>
+									<?php esc_html_e('How to create API credentials?', 'smaily'); ?>
 								</a>
 							</td>
 						</tr>
 						<tr class="form-field">
 							<th scope="row">
-								<label for="api-subdomain"><?php echo esc_html__('Subdomain', 'smaily'); ?></label>
+								<label for="api-subdomain">
+									<?php esc_html_e('Subdomain', 'smaily'); ?>
+								</label>
 							</th>
 							<td>
 								<input id="api-subdomain" name="api[subdomain]" value="<?php echo ($this->credentials['subdomain']) ? esc_html($this->credentials['subdomain']) : ''; ?>" type="text" />
@@ -133,7 +134,9 @@ if ($has_woocommerce) {
 						</tr>
 						<tr class="form-field">
 							<th scope="row">
-								<label for="api-username"><?php echo esc_html__('API username', 'smaily'); ?></label>
+								<label for="api-username">
+									<?php esc_html_e('API username', 'smaily'); ?>
+								</label>
 							</th>
 							<td>
 								<input id="api-username" name="api[username]" value="<?php echo ($this->credentials['username']) ? esc_html($this->credentials['username']) : ''; ?>" type="text" />
@@ -141,19 +144,23 @@ if ($has_woocommerce) {
 						</tr>
 						<tr class="form-field">
 							<th scope="row">
-								<label for="api-password"><?php echo esc_html__('API password', 'smaily'); ?></label>
+								<label for="api-password">
+									<?php esc_html_e('API password', 'smaily'); ?>
+								</label>
 							</th>
 							<td>
-								<input id="api-password" name="api[password]" value="<?php echo ($this->credentials['password']) ? esc_html($this->credentials['password']) : ''; ?>" type="password" autocomplete="off" />
+								<input id="api-password" name="api[password]" value="<?php echo ($this->credentials['password']) ? esc_html($this->credentials['password']) : '' ; ?>" type="password" autocomplete="off" />
 							</td>
 						</tr>
 						<tr class="form-field">
 							<th scope="row">
-								<span><?php echo esc_html__('Subscribe Widget', 'smaily'); ?></span>
+								<span>
+									<?php esc_html_e('Subscribe Widget', 'smaily'); ?>
+								</span>
 							</th>
 							<td>
 								<?php
-								echo esc_html__(
+								esc_html_e(
 									'To add a subscribe widget, use Widgets menu. Validate credentials before using.',
 									'smaily'
 								);
@@ -165,15 +172,16 @@ if ($has_woocommerce) {
 			</div>
 
 			<div id="newsletter">
-
 				<table class="form-table">
 					<tbody>
 						<tr class="form-field">
 							<th scope="row">
 								<label for="is_advanced">
-									<?php echo esc_html__('Is it advanced?', 'smaily'); ?>
+									<?php esc_html_e('Is it advanced?', 'smaily'); ?>
 								</label>
-								<p style="font-size:10px; font-weight: 400;"><?php echo esc_html__('Note: When you save with advanced option switched OFF, default form will be used.', 'smaily-for-wp'); ?></p>
+								<p style="font-size:10px; font-weight: 400;">
+									<?php esc_html_e('Note: When you save with advanced option switched OFF, default form will be used.', 'smaily-for-wp'); ?>
+								</p>
 							</th>
 							<td>
 								<input name="advanced-form[is_advanced]" type="checkbox" <?php checked($this->settings['is_advanced']); ?> class="smaily-toggle" id="is_advanced" value="<?php echo (int)esc_html($this->settings['is_advanced']); ?>" />
@@ -183,17 +191,22 @@ if ($has_woocommerce) {
 						<tr class="form-field is-advanced-row">
 							<th scope="row">
 								<label for="smaily-advanced-form">
-									<?php echo esc_html__('Advanced form', 'smaily'); ?> <a id="reset-form" href="#">(generate)</a>
+									<?php esc_html_e('Advanced form', 'smaily'); ?>
+									<a id="reset-form" href="#">
+										<?php esc_html_e("(generate)") ?>
+									</a>
 								</label>
 							</th>
 							<td>
-								<textarea name="advanced-form[form]" id="smaily-advanced-form" cols="15" rows="15"><?php echo esc_html($this->settings['form']); ?></textarea>
+								<textarea name="advanced-form[form]" id="smaily-advanced-form" cols="15" rows="15">
+									<?php echo esc_html($this->settings['form']); ?>
+								</textarea>
 							</td>
 						</tr>
 					</tbody>
 				</table>
-
 			</div>
+
 			<?php if ($has_woocommerce) : ?>
 				<div id="customer">
 					<table class="form-table">
@@ -201,7 +214,7 @@ if ($has_woocommerce) {
 							<tr class="form-field">
 								<th scope="row">
 									<label for="customer-sync-enabled">
-										<?php echo esc_html__('Enable Customer synchronization', 'smaily'); ?>
+										<?php esc_html_e('Enable Customer synchronization', 'smaily'); ?>
 									</label>
 								</th>
 								<td>
@@ -212,7 +225,7 @@ if ($has_woocommerce) {
 							<tr class="form-field">
 								<th scope="row">
 									<label for="customer-sync-fields">
-										<?php echo esc_html__('Syncronize additional fields', 'smaily'); ?>
+										<?php esc_html_e('Syncronize additional fields', 'smaily'); ?>
 									</label>
 								</th>
 								<td>
@@ -234,16 +247,16 @@ if ($has_woocommerce) {
 										// Add options for select and select them if allready saved before.
 										foreach ($sync_options as $value => $name): ?>
 											<option 
-												value="<?= esc_html($value) ?>"
-												<?= in_array($value, $sync_additional, true) ? 'selected' : '' ?>
+												value="<?php echo esc_attr($value) ?>"
+												<?php echo in_array($value, $sync_additional, true) ? 'selected' : '' ?>
 											>
-												<?= esc_html($name) ?>
+												<?php echo esc_html($name) ?>
 											</option>
 											<?php endforeach ?>
 									</select>
 									<small class="form-text text-muted">
 										<?php
-										echo esc_html__(
+										esc_html_e(
 											'Select fields you wish to synchronize along with subscriber email and store URL',
 											'smaily'
 										);
@@ -261,7 +274,7 @@ if ($has_woocommerce) {
 							<tr class="form-field">
 								<th scope="row">
 									<label for="abandoned-cart-enabled">
-										<?php echo esc_html__('Enable Abandoned Cart reminder', 'smaily'); ?>
+										<?php esc_html_e('Enable Abandoned Cart reminder', 'smaily'); ?>
 									</label>
 								</th>
 								<td>
@@ -272,7 +285,7 @@ if ($has_woocommerce) {
 							<tr class="form-field">
 								<th scope="row">
 									<label for="abandoned-cart-autoresponder">
-										<?php echo esc_html__('Cart Autoresponder ID', 'smaily'); ?>
+										<?php esc_html_e('Cart Autoresponder ID', 'smaily'); ?>
 									</label>
 								</th>
 								<td>
@@ -280,7 +293,7 @@ if ($has_woocommerce) {
 										<?php if (!empty($autoresponder_list)) : ?>
 											<?php foreach ($autoresponder_list as $autoresponder_id => $autoresponder_name) : ?>
 												<option
-													value="<?= esc_html($autoresponder_id) ?>"
+													value="<?php echo esc_attr($autoresponder_id) ?>"
 													<?php selected($cart_autoresponder_id, $autoresponder_id); ?>
 												>
 													<?php echo esc_html($autoresponder_name); ?>
@@ -288,7 +301,7 @@ if ($has_woocommerce) {
 											<?php endforeach; ?>
 										<?php else : ?>
 											<option value="">
-												<?php echo esc_html__('No automations created', 'smaily'); ?>
+												<?php esc_html_e('No automations created', 'smaily'); ?>
 											</option>
 										<?php endif; ?>
 									</select>
@@ -297,7 +310,7 @@ if ($has_woocommerce) {
 							<tr class="form-field">
 								<th scope="row">
 									<label for="abandoned-cart-fields">
-										<?php echo esc_html__('Additional cart fields', 'smaily'); ?>
+										<?php esc_html_e('Additional cart fields', 'smaily'); ?>
 									</label>
 								</th>
 								<td>
@@ -318,16 +331,16 @@ if ($has_woocommerce) {
 										// Add options for select and select them if allready saved before.
 										foreach ($cart_fields as $value => $name): ?>
 											<option
-												value="<?= esc_html($value) ?>"
-												<?= in_array($value, $cart_options, true) ? 'selected' : '' ?>
+												value="<?php echo esc_attr($value) ?>"
+												<?php echo in_array($value, $cart_options, true) ? 'selected' : '' ?>
 											>
-												<?= esc_html($name) ?>
+												<?php echo esc_html($name) ?>
 											</option>
 										<?php endforeach ?>
 									</select>
 									<small id="cart-options-help" class="form-text text-muted">
 										<?php
-										echo esc_html__(
+										esc_html_e(
 											'Select fields wish to send to Smaily template along with subscriber email and store url.',
 											'smaily'
 										);
@@ -338,15 +351,14 @@ if ($has_woocommerce) {
 							<tr class="form-field">
 								<th scope="row">
 									<label for="abandoned-cart-delay">
-										<?php echo esc_html__('Cart cutoff time', 'smaily'); ?>
+										<?php esc_html_e('Cart cutoff time', 'smaily'); ?>
 									</label>
 								</th>
-								<td> <?php echo esc_html__('Consider cart abandoned after:', 'smaily'); ?>
+								<td> <?php esc_html_e('Consider cart abandoned after:', 'smaily'); ?>
 									<input id="abandoned-cart-delay" name="abandoned_cart[delay]" style="width:65px;" value="<?php echo ($cart_cutoff) ? esc_html($cart_cutoff) : ''; ?>" type="number" min="10" />
-									<?php echo esc_html__('minute(s)', 'smaily'); ?>
-
+									<?php esc_html_e('minute(s)', 'smaily'); ?>
 									<small class="form-text text-muted">
-										<?php echo esc_html__('Minimum 10 minutes.', 'smaily'); ?>
+										<?php esc_html_e('Minimum 10 minutes.', 'smaily'); ?>
 									</small>
 								</td>
 							</tr>
@@ -360,7 +372,7 @@ if ($has_woocommerce) {
 							<tr class="form-field">
 								<th scope="row">
 									<span>
-										<?php echo esc_html__('Subscription checkbox', 'smaily'); ?>
+										<?php esc_html_e('Subscription checkbox', 'smaily'); ?>
 									</span>
 								</th>
 								<td>
@@ -375,7 +387,7 @@ if ($has_woocommerce) {
 							<tr class="form-field">
 								<th scope="row">
 									<label for="checkout-checkbox-enabled">
-										<?php echo esc_html__('Enable', 'smaily'); ?>
+										<?php esc_html_e('Enable', 'smaily'); ?>
 									</label>
 								</th>
 								<td>
@@ -386,7 +398,7 @@ if ($has_woocommerce) {
 							<tr class="form-field">
 								<th scope="row">
 									<label for="checkout-checkbox-auto-check">
-										<?php echo esc_html__('Checked by default', 'smaily'); ?>
+										<?php esc_html_e('Checked by default', 'smaily'); ?>
 									</label>
 								</th>
 								<td>
@@ -396,16 +408,16 @@ if ($has_woocommerce) {
 							<tr class="form-field">
 								<th scope="row">
 									<label for="checkout-checkbox-location">
-										<?php echo esc_html__('Location', 'smaily'); ?>
+										<?php esc_html_e('Location', 'smaily'); ?>
 									</label>
 								</th>
 								<td>
 									<select name="checkout_checkbox[position]">
 										<option value="before" <?php echo ('before' === $cb_order_selected ? 'selected' : ''); ?>>
-											<?php echo esc_html__('Before', 'smaily'); ?>
+											<?php esc_html_e('Before', 'smaily'); ?>
 										</option>
 										<option value="after" <?php echo ('after' === $cb_order_selected ? 'selected' : ''); ?>>
-											<?php echo esc_html__('After', 'smaily'); ?>
+											<?php esc_html_e('After', 'smaily'); ?>
 										</option>
 									</select>
 									<select id="checkout-checkbox-location" name="checkout_checkbox[location]">
@@ -420,7 +432,7 @@ if ($has_woocommerce) {
 										foreach ($cb_loc_available as $loc_value => $loc_translation) :
 										?>
 											<option
-												value="<?php echo esc_html($loc_value); ?>"
+												value="<?php echo esc_attr($loc_value); ?>"
 												<?php echo $cb_loc_selected === $loc_value ? 'selected' : ''; ?>
 											>
 												<?php echo esc_html($loc_translation); ?>
@@ -439,14 +451,14 @@ if ($has_woocommerce) {
 							<tr class="form-field">
 								<th scope="row">
 									<label for="rss-limit">
-										<?php echo esc_html__('Product limit', 'smaily'); ?>
+										<?php esc_html_e('Product limit', 'smaily'); ?>
 									</label>
 								</th>
 								<td>
 									<input type="number" id="rss-limit" name="rss[limit]" class="smaily-rss-options" min="1" max="250" value="<?php echo esc_html($rss_limit); ?>" />
 									<small>
 										<?php
-										echo esc_html__(
+										esc_html_e(
 											'Limit how many products you will add to your field. Maximum 250.',
 											'smaily'
 										);
@@ -457,7 +469,7 @@ if ($has_woocommerce) {
 							<tr class="form-field">
 								<th scope="row">
 									<label for="rss-category">
-										<?php echo esc_html__('Product category', 'smaily'); ?>
+										<?php esc_html_e('Product category', 'smaily'); ?>
 									</label>
 								</th>
 								<td>
@@ -466,17 +478,17 @@ if ($has_woocommerce) {
 										// Display available WooCommerce product categories and saved category.
 										foreach ($wc_categories_list as $category) :
 										?>
-											<option value="<?php echo esc_html($category->slug); ?>" <?php echo $rss_category === $category->slug ? 'selected' : ''; ?>>
+											<option value="<?php echo esc_attr($category->slug); ?>" <?php echo $rss_category === $category->slug ? 'selected' : ''; ?>>
 												<?php echo esc_html($category->name); ?>
 											</option>
 										<?php endforeach; ?>
 										<option value="" <?php echo empty($rss_category) ? 'selected' : ''; ?>>
-											<?php echo esc_html__('All products', 'smaily'); ?>
+											<?php esc_html_e('All products', 'smaily'); ?>
 										</option>
 									</select>
 									<small>
 										<?php
-										echo esc_html__(
+										esc_html_e(
 											'Show products from specific category',
 											'smaily'
 										);
@@ -487,7 +499,7 @@ if ($has_woocommerce) {
 							<tr class="form-field">
 								<th scope="row">
 									<label for="rss-sort-field">
-										<?php echo esc_html__('Order products by', 'smaily'); ?>
+										<?php esc_html_e('Order products by', 'smaily'); ?>
 									</label>
 								</th>
 								<td id="smaily_rss_order_options">
@@ -504,17 +516,17 @@ if ($has_woocommerce) {
 										// Display option and select saved value.
 										foreach ($sort_categories_available as $sort_value => $sort_name) :
 										?>
-											<option <?php selected($rss_order_by, $sort_value); ?> value="<?php echo esc_html($sort_value); ?>">
+											<option <?php selected($rss_order_by, $sort_value); ?> value="<?php echo esc_attr($sort_value); ?>">
 												<?php echo esc_html($sort_name); ?>
 											</option>
 										<?php endforeach; ?>
 									</select>
 									<select id="rss-sort-order" name="rss[sort_order]" class="smaily-rss-options">
 										<option value="ASC" <?php selected($rss_order, 'ASC'); ?>>
-											<?php echo esc_html__('Ascending', 'smaily'); ?>
+											<?php esc_html_e('Ascending', 'smaily'); ?>
 										</option>
 										<option value="DESC" <?php selected($rss_order, 'DESC'); ?>>
-											<?php echo esc_html__('Descending', 'smaily'); ?>
+											<?php esc_html_e('Descending', 'smaily'); ?>
 										</option>
 									</select>
 								</td>
@@ -522,7 +534,7 @@ if ($has_woocommerce) {
 							<tr class="form-field">
 								<th scope="row">
 									<span>
-										<?php echo esc_html__('Product RSS feed', 'smaily'); ?>
+										<?php esc_html_e('Product RSS feed', 'smaily'); ?>
 									</span>
 								</th>
 								<td>
@@ -531,7 +543,7 @@ if ($has_woocommerce) {
 									</strong>
 									<small>
 										<?php
-										echo esc_html__(
+										esc_html_e(
 											"Copy this URL into your template editor's RSS block, to receive RSS-feed.",
 											'smaily'
 										);
@@ -544,7 +556,7 @@ if ($has_woocommerce) {
 				</div>
 			<?php endif; ?>
 			<button type="submit" name="save" class="button-primary">
-				<?php echo esc_html__('Save Settings', 'smaily'); ?>
+				<?php esc_html_e('Save Settings', 'smaily'); ?>
 			</button>
 		</form>
 	</div>


### PR DESCRIPTION
Unifies patterns used for echoing out text in smaily-admin.php file. Also drops deprecated get_terms function call signature usage.