### PR TITLE
Suppress database related phpcs warnings

### DIFF
--- a/includes/smaily-lifecycle.class.php
+++ b/includes/smaily-lifecycle.class.php
@@ -1,8 +1,10 @@
 <?php
-
 /**
  * Define all the logic related to plugin lifecycle
  *
+ * 
+ * Using custom database table that requires direct queries.
+ * @phpcs:disable WordPress.DB.DirectDatabaseQuery
  * @package    Smaily
  * @subpackage Smaily/includes
  */
@@ -82,9 +84,10 @@ class Smaily_Lifecycle
 
 		// Create smaily_abandoned_cart table if it does not exist.
 		$abandoned_table_name = $wpdb->prefix . 'smaily_abandoned_carts';
+		$query = $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $abandoned_table_name));
 
 		// Check if the table already exists.
-		if ($wpdb->get_var("SHOW TABLES LIKE '$abandoned_table_name'") != $abandoned_table_name) {
+		if ($query != $abandoned_table_name) {
 			$abandoned = "CREATE TABLE $abandoned_table_name (
 				customer_id int(11) NOT NULL,
 				cart_updated datetime DEFAULT '0000-00-00 00:00:00',

--- a/woocommerce/cart.class.php
+++ b/woocommerce/cart.class.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Using custom database table that requires direct queries.
+ * @phpcs:disable WordPress.DB.DirectDatabaseQuery
+ * 
+ */
 
 namespace Smaily_WC;
 
@@ -89,7 +94,6 @@ class Cart
 					array('customer_id' => $user_id)
 				);
 			} else {
-				// Delete cart if empty.
 				$wpdb->delete(
 					$table,
 					array(

--- a/woocommerce/cron.class.php
+++ b/woocommerce/cron.class.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Using custom database table that requires direct queries.
+ * @phpcs:disable WordPress.DB.DirectDatabaseQuery
+ * 
+ */
 
 namespace Smaily_WC;
 
@@ -88,8 +93,8 @@ class Cron
 			// Get all users with subscribed status.
 			$users = get_users(
 				array(
-					'meta_key'   => 'user_newsletter',
-					'meta_value' => 1,
+					'meta_key'   => 'user_newsletter', // phpcs:ignore WordPress.DB.SlowDBQuery
+					'meta_value' => 1, // phpcs:ignore WordPress.DB.SlowDBQuery
 				)
 			);
 


### PR DESCRIPTION
Most of DB related warnings is caused by using direct queries, however direct queries are required as we are accessing a custom table. This PR disables phpcs database related rules where needed.

Abandoned cart creation query is now prepared for execution instead of directly providing the table name value.