### PR TITLE
Update readme and smaily.php according to WordPress standards

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,14 +1,14 @@
 === Smaily ===
 Contributors: sendsmaily, kaarel, tomabel, marispulk, tanely
-Tags: woocommerce, smaily, newsletter, email, widget, plugin, sidebar, api, mail, marketing, contact form 7
+Tags: smaily, newsletter, email, mail, marketing
 Requires PHP: 5.6
 Requires at least: 4.5
 Tested up to: 8.1
 WC tested up to: 8.7.0
-Stable tag: 4.0.0
+Stable tag: 1.0.0
 License: GPLv3 or later
 
-Comprehensive Smaily integration for WordPress, WooCommerce, and Contact Form 7, offering seamless newsletter sign-up and automation features across your site.
+The Smaily plugin integrates Contact Form 7 and WooCommerce, offering a complete email marketing and automation solution.
 
 == Description ==
 

--- a/smaily.php
+++ b/smaily.php
@@ -2,12 +2,12 @@
 /*
  * Plugin Name:       Smaily
  * Text Domain:       smaily
- * Description:       Smaily integration plugin that includes WooCommerce and Contact Form 7 implementations.
+ * Description:       Smaily integration plugin that includes WooCommerce and Contact Form 7 integrations.
  * Version:           1.0.0
  * Author:            Sendsmaily LLC
  * Author URI:        https://smaily.com
- * License:           GPL-2.0+
- * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
+ * License:           GPL-3.0+
+ * License URI:       https://www.gnu.org/licenses/gpl-3.0.en.html
 */
 
 if (!defined('ABSPATH')) {


### PR DESCRIPTION
Address problems in readme and smaily.php.

- Limits tags to 5
- Shorten plugin description
- Downgrade stable tag to v 1.0.0
- Use GPL-3 license