### PR TITLE
Add GitHub action to lint code

### DIFF
--- a/.github/workflows/wpcs.yml
+++ b/.github/workflows/wpcs.yml
@@ -1,0 +1,17 @@
+name: Lint the codebase
+
+on: pull_request
+
+jobs:
+  phpcs:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: php-actions/composer@v6
+      with:
+        php_version: 7.0
+    - uses: php-actions/composer@v6
+      with:
+        php_version: 7.0
+        command: run lint

--- a/smaily.php
+++ b/smaily.php
@@ -10,7 +10,7 @@
  * License URI:       https://www.gnu.org/licenses/gpl-3.0.en.html
 */
 
-if ( ! defined( 'ABSPATH' )) {
+if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 

--- a/smaily.php
+++ b/smaily.php
@@ -10,7 +10,7 @@
  * License URI:       https://www.gnu.org/licenses/gpl-3.0.en.html
 */
 
-if ( ! defined( 'ABSPATH' ) ) {
+if ( ! defined( 'ABSPATH' )) {
 	exit; // Exit if accessed directly.
 }
 


### PR DESCRIPTION
Implements an github action to lint code automatically. This aims to further improve code quality by not allowing code with linting errors to be merged.