### PR TITLE
php-compatibility: Improve compatibility with PHP versions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "phpcs.executablePath": "vendor/bin/phpcs"
+    "phpcs.executablePath": "vendor/bin/phpcs",
+    "editor.inlayHints.enabled": "offUnlessPressed",
 }

--- a/public/partials/smaily-public-advanced.php
+++ b/public/partials/smaily-public-advanced.php
@@ -2,4 +2,4 @@
 
 // Administrator controlled html.
 // phpcs:ignore  WordPress.Security.EscapeOutput.OutputNotEscaped
-echo html_entity_decode( $this->form );
+echo html_entity_decode( $this->form, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );

--- a/woocommerce/cron.class.php
+++ b/woocommerce/cron.class.php
@@ -288,7 +288,7 @@ class Cron {
 					}
 
 					foreach ( $product as $key => $value ) {
-						$addresses[ $key . '_' . $i ] = htmlspecialchars( $value );
+						$addresses[ $key . '_' . $i ] = htmlspecialchars( $value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
 					}
 					++$i;
 				}
@@ -338,7 +338,7 @@ class Cron {
 			)
 		);
 
-		return wp_strip_all_tags( html_entity_decode( $price ) );
+		return wp_strip_all_tags( html_entity_decode( $price, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ) );
 	}
 
 	/**
@@ -358,7 +358,7 @@ class Cron {
 			)
 		);
 
-		return wp_strip_all_tags( html_entity_decode( $price ) );
+		return wp_strip_all_tags( html_entity_decode( $price, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ) );
 	}
 
 	/**

--- a/woocommerce/data-handler.class.php
+++ b/woocommerce/data-handler.class.php
@@ -28,7 +28,7 @@ class Data_Handler {
 			}
 
 			$price = floatval( $product->get_price() );
-			$price = number_format( floatval( $price ), 2, '.', ',' ) . html_entity_decode( $currencysymbol );
+			$price = number_format( floatval( $price ), 2, '.', ',' ) . html_entity_decode( $currencysymbol, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
 
 			$discount = 0;
 			// Get product price when on sale.
@@ -43,7 +43,7 @@ class Data_Handler {
 					$discount = round( 100 - ( $sale_price / $regular_price * 100 ), 2 );
 				}
 				// Format price and add currency symbol.
-				$regular_price = number_format( floatval( $regular_price ), 2, '.', ',' ) . html_entity_decode( $currencysymbol );
+				$regular_price = number_format( floatval( $regular_price ), 2, '.', ',' ) . html_entity_decode( $currencysymbol, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
 			}
 
 			$url   = get_permalink( $prod->get_id() );

--- a/woocommerce/profile-settings.class.php
+++ b/woocommerce/profile-settings.class.php
@@ -325,7 +325,7 @@ class Profile_Settings {
 		$user_data = array();
 
 		foreach ( $fields as $key => $value ) {
-			if ( $this->smaily_is_userdata( key: $key ) ) {
+			if ( $this->smaily_is_userdata( $key ) ) {
 				$user_data[ $key ] = $value;
 				continue;
 			}


### PR DESCRIPTION
This PR fixes a mistakenly added named argument in function call. This was probably caused due to a not intentional double-click on the variable. To mitigate the issue I have set editor inlay hints to be visible only when holding ctrl + alt keys.

As the issue came out with PHPCompatibility rule that has not landed in any of the master versions. I scanned the codebase with the `development` branch of the package. I also fixed issues that came out regarding php 8.1 compatibility.