### PR TITLE
Update WP and PHP minimum supported versions

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -22,7 +22,7 @@
         <include-pattern>*\.php$</include-pattern>
     </rule>
 
-    <config name="minimum_supported_wp_version" value="4.5" />
+    <config name="minimum_supported_wp_version" value="5.0" />
 
     <rule ref="WordPress.WP.I18n">
         <properties>

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Smaily ===
 Contributors: sendsmaily, kaarel, tomabel, marispulk, tanely
 Tags: smaily, newsletter, email, mail, marketing
-Requires PHP: 5.6
-Requires at least: 4.5
+Requires PHP: 7.0
+Requires at least: 5.0
 Tested up to: 6.7
-WC tested up to: 8.7.0
+WC tested up to: 9.6.1
 Stable tag: 1.0.0
 License: GPLv3 or later
 


### PR DESCRIPTION
Updates the minimum PHP version to v7.0 and the minimum WordPress version to v5.0.