### PR TITLE
Use single implementation for listing autoresponders

### DIFF
--- a/admin/js/admin-widget.js
+++ b/admin/js/admin-widget.js
@@ -1,13 +1,13 @@
 // Run jQuery in no-conflict mode for WP development.
 jQuery( document ).ready(function($) {
 
-    // Initate jscolor.install on widget-added.
+    // Initiate jscolor.install on widget-added.
     $( document ).on( 'widget-added', function ( event, widget ) {
         // Load jscolor.
         jscolor.install();
     });
 
-    // Initate jscolor.install on widget update(save).
+    // Initiate jscolor.install on widget update(save).
     $( document ).on( 'widget-updated', function ( event, widget ) {
         // Load jscolor.
         jscolor.install();

--- a/admin/smaily-admin-settings.class.php
+++ b/admin/smaily-admin-settings.class.php
@@ -3,7 +3,6 @@
 namespace Smaily_Admin;
 
 use Smaily_Options;
-use Smaily_Request;
 use Smaily_WC\Rss;
 
 class Settings {
@@ -183,7 +182,7 @@ class Settings {
 			$page,
 			$abandoned_cart_section,
 			array(
-				'autoresponders' => $this->get_autoresponders(),
+				'autoresponders' => Admin::get_autoresponders( $this->options ),
 			)
 		);
 
@@ -447,32 +446,5 @@ class Settings {
 			$page,
 			$rss_section
 		);
-	}
-
-	/**
-	 * Make a request to Smaily asking for autoresponders.
-	 * Request is authenticated via saved credentials.
-	 *
-	 * @return array List of autoresponders in format [id => title].
-	 */
-	private function get_autoresponders() {
-		if ( ! $this->options->has_credentials() ) {
-			return array();
-		}
-
-		$request = new Smaily_Request( $this->options );
-		$result  = $request->list_autoresponders();
-
-		if ( empty( $result['body'] ) ) {
-			return array();
-		}
-
-		$autoresponder_list = array();
-		foreach ( $result['body'] as $autoresponder ) {
-			$id                        = $autoresponder['id'];
-			$title                     = $autoresponder['title'];
-			$autoresponder_list[ $id ] = $title;
-		}
-		return $autoresponder_list;
 	}
 }

--- a/admin/smaily-admin.class.php
+++ b/admin/smaily-admin.class.php
@@ -251,6 +251,34 @@ class Admin {
 	}
 
 	/**
+	 * Make a request to Smaily asking for autoresponders.
+	 * Request is authenticated via saved credentials.
+	 *
+	 * @param Smaily_Options $options
+	 * @return array List of autoresponders in format [id => title].
+	 */
+	public static function get_autoresponders( Smaily_Options $options ) {
+		if ( ! $options->has_credentials() ) {
+			return array();
+		}
+
+		$request = new Smaily_Request( $options );
+		$result  = $request->list_autoresponders();
+
+		if ( empty( $result['body'] ) ) {
+			return array();
+		}
+
+		$autoresponder_list = array();
+		foreach ( $result['body'] as $autoresponder ) {
+			$id                        = $autoresponder['id'];
+			$title                     = $autoresponder['title'];
+			$autoresponder_list[ $id ] = $title;
+		}
+		return $autoresponder_list;
+	}
+
+	/**
 	 * Lists available admin page tabs.
 	 *
 	 * @return array

--- a/cf7/admin.class.php
+++ b/cf7/admin.class.php
@@ -2,21 +2,18 @@
 
 namespace Smaily_CF7;
 
-use Smaily_Options;
-use Smaily_Request;
-
 defined( 'ABSPATH' ) || exit;
 
-use WPCF7_Integration;
+use Smaily_Admin\Admin as Smaily_Admin;
+use Smaily_Options;
 use WPCF7_ContactForm;
+use WPCF7_Integration;
 
 /**
  * Class for managing all admin related functionality of Contact Form 7 integration
  */
 
 class Admin {
-
-
 	/**
 	 * @var \Smaily_Options Instance of Smaily_Options.
 	 */
@@ -108,7 +105,7 @@ class Admin {
 		$has_credentials = $this->options->has_credentials();
 
 		// Fetch autoresponder data here for view.
-		$autoresponder_list = $this->get_autoresponders(); //TODO: Move this to smaily API.
+		$autoresponder_list = Smaily_Admin::get_autoresponders( $this->options );
 
 		$form_tags       = \WPCF7_FormTagsManager::get_instance()->get_scanned_tags();
 		$captcha_enabled = $this->is_captcha_enabled( $form_tags );
@@ -120,7 +117,7 @@ class Admin {
 	 * Search provided tags for Really Simple Captcha tags.
 	 *
 	 * Loops through all lists of tags until it finds 'basetype' key with value
-	 *  'captchac' or 'captchar'. If found, sets a var true and evaluates both for response.
+	 * 'captchac' or 'captchar'. If found, sets a var true and evaluates both for response.
 	 *
 	 * @param array $form_tags All Contact Form 7 tags in current form.
 	 * @return bool $simple_captcha_enabled
@@ -157,33 +154,5 @@ class Admin {
 			return true;
 		}
 		return false;
-	}
-
-	/**
-	 * Make a request to Smaily asking for autoresponders.
-	 * Request is authenticated via saved credentials.
-	 *
-	 * @return array $autoresponder_list List of autoresponders in format [id => title].
-	 */
-	private function get_autoresponders() {
-		if ( ! $this->options->has_credentials() ) {
-			return array();
-		}
-
-		$request = new Smaily_Request( $this->options );
-		$result  = $request->list_autoresponders();
-
-		if ( empty( $result['body'] ) ) {
-			return array();
-		}
-
-		$autoresponder_list = array();
-		foreach ( $result['body'] as $autoresponder ) {
-			$id                        = $autoresponder['id'];
-			$title                     = $autoresponder['title'];
-			$autoresponder_list[ $id ] = $title;
-		}
-
-		return $autoresponder_list;
 	}
 }

--- a/includes/smaily-api.class.php
+++ b/includes/smaily-api.class.php
@@ -77,12 +77,12 @@ class Smaily_API {
 	}
 
 	/**
-	 * List available autoresponders.
+	 * List available autoresponders to be used as block options.
 	 *
 	 * @return array{label: string, value: string}
 	 */
 	public function list_autoresponders() {
-		$autoresponders = $this->admin_model->get_autoresponders();
+		$autoresponders = Admin::get_autoresponders( $this->options );
 
 		$response = array();
 		foreach ( $autoresponders as $id => $title ) {

--- a/includes/smaily-widget.class.php
+++ b/includes/smaily-widget.class.php
@@ -127,6 +127,7 @@ class Smaily_Widget extends WP_Widget {
 			)
 		);
 
+		$autoresponders        = Admin::get_autoresponders( $this->options );
 		$title_id              = $this->get_field_id( 'title' );
 		$title_name            = $this->get_field_name( 'title' );
 		$show_name_id          = $this->get_field_id( 'show_name' );
@@ -159,38 +160,11 @@ class Smaily_Widget extends WP_Widget {
 			<label for="<?php echo esc_attr( $autoresponder_id ); ?>"><?php esc_html_e( 'Autoresponder ID', 'smaily' ); ?>:</label>
 			<select id="<?php echo esc_attr( $autoresponder_id ); ?>" name="<?php echo esc_attr( $autoresponder_id_name ); ?>">
 				<option value=""><?php esc_html_e( 'No autoresponder', 'smaily' ); ?></option>
-				<?php foreach ( $this->get_autoresponders() as $id => $title ) : ?>
+				<?php foreach ( $autoresponders as $id => $title ) : ?>
 					<option value="<?php echo esc_attr( $id ); ?>" <?php selected( $instance['autoresponder_id'], $id ); ?>><?php echo esc_attr( $title ); ?></option>
 				<?php endforeach; ?>
 			</select>
 		</p>
 		<?php
-	}
-
-	/**
-	 * Make a request to Smaily asking for autoresponders.
-	 * Request is authenticated via saved credentials.
-	 *
-	 * @return array List of autoresponders in format [id => title].
-	 */
-	private function get_autoresponders() {
-		if ( ! $this->options->has_credentials() ) {
-			return array();
-		}
-
-		$request = new Smaily_Request( $this->options );
-		$result  = $request->list_autoresponders();
-
-		if ( empty( $result['body'] ) ) {
-			return array();
-		}
-
-		$autoresponder_list = array();
-		foreach ( $result['body'] as $autoresponder ) {
-			$id                        = $autoresponder['id'];
-			$title                     = $autoresponder['title'];
-			$autoresponder_list[ $id ] = $title;
-		}
-		return $autoresponder_list;
 	}
 }

--- a/woocommerce/profile-settings.class.php
+++ b/woocommerce/profile-settings.class.php
@@ -303,7 +303,7 @@ class Profile_Settings {
 			}
 
 			$sanitize = isset( $field_args['sanitize'] ) ? $field_args['sanitize'] : 'wc_clean';
-			$value = isset( $_POST[ $key ] ) ? call_user_func( $sanitize, wp_unslash( $_POST[ $key ] ) ) : '';
+			$value    = isset( $_POST[ $key ] ) ? call_user_func( $sanitize, wp_unslash( $_POST[ $key ] ) ) : '';
 
 			$fields[ $key ] = $value;
 		}


### PR DESCRIPTION
Use single implementation of listing autoresponders reducing duplicate code. Fixes also spelling and formatting issues.