### PR TITLE
Stop subscribing user with id 1

### DIFF
--- a/woocommerce/cron.class.php
+++ b/woocommerce/cron.class.php
@@ -101,9 +101,6 @@ class Cron {
 			}
 		}
 
-		// TODO: Why?
-		update_user_meta( 1, 'user_newsletter', 1 );
-
 		// Get all users with subscribed status.
 		$users = get_users(
 			array(


### PR DESCRIPTION
Removes the code that always subscribes user with the ID of 1. I think this is leftover of some debugging code.