### PR TITLE
maint: Remove nonce verification recommended check

### DIFF
--- a/admin/partials/smaily-admin-page.php
+++ b/admin/partials/smaily-admin-page.php
@@ -9,8 +9,8 @@ defined( 'ABSPATH' ) || exit;
 
 $tabs        = $this->list_admin_page_tabs();
 $current_tab = array_keys( $tabs )[0];
-if ( isset( $_GET['tab'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	$tab = sanitize_text_field( wp_unslash( $_GET['tab'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+if ( isset( $_GET['tab'] ) ) {
+	$tab = sanitize_text_field( wp_unslash( $_GET['tab'] ) );
 	if ( array_key_exists( $tab, $tabs ) ) {
 		$current_tab = $tab;
 	}

--- a/blocks/newsletter-signup/src/render.php
+++ b/blocks/newsletter-signup/src/render.php
@@ -2,8 +2,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
-$has_response = isset( $_GET['code'] ); //phpcs:ignore WordPress.Security.NonceVerification.Recommended
-$is_success   = $has_response && $_GET['code'] === '101'; //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+$has_response = isset( $_GET['code'] );
+$is_success   = $has_response && $_GET['code'] === '101';
 $is_error     = $has_response && ! $is_success;
 
 $language_code = \Smaily_Helper::get_current_language_code();

--- a/cf7/partials/smaily-cf7-admin.php
+++ b/cf7/partials/smaily-cf7-admin.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 ?>
-<?php if ( ! isset( $_GET['post'] ) ) : // phpcs:ignore  WordPress.Security.NonceVerification.Recommended ?>
+<?php if ( ! isset( $_GET['post'] ) ) : ?>
 	<div id='form-id-unknown'>
 		<p id='smailyforcf7-form-id-error' style='padding:15px; background-color:#f2dede; margin:0 0 10px;'>
 			<?php

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -11,7 +11,9 @@
     <arg name="parallel" value="8" />
     <arg name="extensions" value="php" />
 
-    <rule ref="WordPress.Security" />
+    <rule ref="WordPress.Security">
+        <exclude name="WordPress.Security.NonceVerification.Recommended" />
+    </rule>
 
     <rule ref="WordPress-Core">
         <exclude name="WordPress.PHP.YodaConditions.NotYoda" />

--- a/public/partials/smaily-public-basic.php
+++ b/public/partials/smaily-public-basic.php
@@ -7,7 +7,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-$code             = isset( $_GET['code'] ) ? intval( $_GET['code'] ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+$code             = isset( $_GET['code'] ) ? intval( $_GET['code'] ) : null;
 $messages         = array(
 	101 => __( 'Thank you for subscribing to our newsletter.', 'smaily' ),
 	201 => __( 'Form was not submitted using POST method.', 'smaily' ),

--- a/woocommerce/profile-settings.class.php
+++ b/woocommerce/profile-settings.class.php
@@ -285,7 +285,6 @@ class Profile_Settings {
 	 * @return int $user_id Current user ID
 	 */
 	public function smaily_get_edit_user_id() {
-		// phpcs:ignore  WordPress.Security.NonceVerification.Recommended
 		return isset( $_GET['user_id'] ) ? (int) $_GET['user_id'] : get_current_user_id();
 	}
 


### PR DESCRIPTION
This check is tedious in case of casting request values and most places in code ignore this with inline comment. Dropping the rule instead.