### PR TITLE
maint: Fix loading autoresponders on admin pages

### DIFF
--- a/admin/smaily-admin-renderer.class.php
+++ b/admin/smaily-admin-renderer.class.php
@@ -114,7 +114,7 @@ class Renderer {
 	 * @return void
 	 */
 	public function render_abandoned_cart_status_field( $args ) {
-		$autoresponders           = $args['autoresponders'];
+		$autoresponders           = Admin::get_autoresponders( $this->options );
 		$abandoned_cart_status    = get_option( Smaily_Options::ABANDONED_CART_STATUS_OPTION, Smaily_Options::ABANDONED_CART_DEFAULT_STATUS );
 		$enabled                  = $abandoned_cart_status['enabled'];
 		$current_autoresponder_id = $abandoned_cart_status['autoresponder_id'];

--- a/admin/smaily-admin-settings.class.php
+++ b/admin/smaily-admin-settings.class.php
@@ -259,10 +259,7 @@ class Settings {
 			__( 'Enable Abandoned Cart', 'smaily' ),
 			array( $this->renderer, 'render_abandoned_cart_status_field' ),
 			$page,
-			$abandoned_cart_section,
-			array(
-				'autoresponders' => Admin::get_autoresponders( $this->options ),
-			)
+			$abandoned_cart_section
 		);
 
 		add_settings_field(
@@ -274,7 +271,7 @@ class Settings {
 			array(
 				'option_name' => Smaily_Options::ABANDONED_CART_CUTOFF_OPTION,
 				'min'         => Smaily_Options::ABANDONED_CART_DEFAULT_CUTOFF,
-				'help'        => __( 'Minimum 10 minutes', 'smaily' ),
+				'help'        => __( 'Minimum 10 minutes.', 'smaily' ),
 			)
 		);
 


### PR DESCRIPTION
This optimizes API calls by moving the autoresponder loading to the render method, which is only called when the component is actually rendered.