### PR TITLE
fix: Fix abandoned cart messages not delivered

### DIFF
--- a/admin/smaily-admin-settings.class.php
+++ b/admin/smaily-admin-settings.class.php
@@ -271,7 +271,7 @@ class Settings {
 			array(
 				'option_name' => Smaily_Options::ABANDONED_CART_CUTOFF_OPTION,
 				'min'         => Smaily_Options::ABANDONED_CART_DEFAULT_CUTOFF,
-				'help'        => __( 'Minimum 10 minutes.', 'smaily' ),
+				'help'        => __( 'Time in minutes after which the cart is considered abandoned. Minimum 10 minutes.', 'smaily' ),
 			)
 		);
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -22,6 +22,7 @@ services:
         define( 'WP_DEBUG_LOG', true );
         define( 'WP_DEVTOOL', 'source-map' );
         define( 'SCRIPT_DEBUG', true );
+        # define( 'ALTERNATE_WP_CRON' , true );
     volumes:
     - wordpress:/var/www/html
     - ./:/var/www/html/wp-content/plugins/smaily

--- a/includes/smaily-options.class.php
+++ b/includes/smaily-options.class.php
@@ -61,10 +61,11 @@ class Smaily_Options {
 
 	/**
 	 * Default cart cutoff time in minutes.
+	 * Best practice, offering largest potential for conversion.
 	 *
 	 * @var array
 	 */
-	const ABANDONED_CART_DEFAULT_CUTOFF = 10;
+	const ABANDONED_CART_DEFAULT_CUTOFF = 30;
 
 	/**
 	 * Default position for checkout subscription checkbox.

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,8 @@ This is a description of the values that are added to the user's meta data when 
 
 ### Customer synchronization
 
+Customer synchronization is run once per day. The synchronization is triggered by the WordPress cron job.
+
 Automatically added values:
 - `email` - user's email address
 - `store` - store URL
@@ -90,6 +92,14 @@ The following attributes are available:
 - `product_price` - product sale price including tax and with currency
 - `product_image_url` - product image URL. Featured image is used. If not set the first image from the product gallery is used.
 - `over_10_product` - true if there are more than 10 products in the cart
+
+## Abandoned Cart Reminder
+
+The abandoned cart actions are scheduled to run in every 15 minutes. This means that the abandoned carts are marked and notifications are sent in every 15 minutes. User can configure the time when cart is considered abandoned (cart cutoff time) in the plugin settings. The default cutoff time is 30 minutes. This means that the cart is considered abandoned if the user has not completed the purchase in 30 minutes after the last cart update.
+
+As the cron job is scheduled to run in every 15 minutes and the actual time when the abandoned cart reminder is sent can be up to 15 minutes after the cart is considered abandoned. The abandoned cart reminder is sent only once per abandoned cart.
+
+We recommend the default value of 30 minutes for the delay. This is the sweet spot for most of the cases and offers a good balance between reminding the user and not spamming them and offering the largest potential for conversion.
 
 ## Changelog
 

--- a/woocommerce/cron.class.php
+++ b/woocommerce/cron.class.php
@@ -136,7 +136,10 @@ class Cron {
 	 * @return void
 	 */
 	public function smaily_abandoned_carts_email() {
-		$status = get_option( Smaily_Options::ABANDONED_CART_STATUS_OPTION, Smaily_Options::ABANDONED_CART_DEFAULT_STATUS );
+		$status = get_option(
+			Smaily_Options::ABANDONED_CART_STATUS_OPTION,
+			Smaily_Options::ABANDONED_CART_DEFAULT_STATUS
+		);
 		if ( ! $status['enabled'] ) {
 			return;
 		}
@@ -145,8 +148,9 @@ class Cron {
 			Smaily_Options::ABANDONED_CART_FIELDS_OPTION,
 			Smaily_Options::ABANDONED_CART_DEFAULT_FIELDS
 		);
+
 		foreach ( $this->get_abandoned_carts() as $cart ) {
-			$cart = maybe_unserialize( $cart['cart_content'] );
+			$cart_content = maybe_unserialize( $cart['cart_content'] );
 			if ( empty( $cart ) ) {
 				continue;
 			}
@@ -157,10 +161,14 @@ class Cron {
 			}
 
 			$addresses = $this->prepare_user_data( $user, $sync_fields );
-			$products  = $this->prepare_products_data( $cart, $sync_fields );
+			$products  = $this->prepare_products_data( $cart_content, $sync_fields );
 
 			$request  = new Smaily_Request( $this->options );
-			$response = $request->trigger_automation( (int) $status['autoresponder_id'], array_merge( $addresses, $products ), false );
+			$response = $request->trigger_automation(
+				(int) $status['autoresponder_id'],
+				array( array_merge( $addresses, $products ) ),
+				false
+			);
 
 			if ( empty( $response ) ) {
 				return $this->logger->error( 'Failed to trigger abandoned cart email flow - received an empty response' );
@@ -314,7 +322,8 @@ class Cron {
 	 */
 	private function prepare_user_data( WP_User $user, array $options ) {
 		$addresses = array(
-			// is_abandoned_cart field is a business requirement. If same account is used for marketing and abandoned cart, then it is necessary to distinguish
+			// is_abandoned_cart field is a business requirement.
+			// If same account is used for marketing and abandoned cart, then it is necessary to distinguish
 			// between the two. The contact can receive abandoned cart emails, but not marketing emails.
 			'is_abandoned_cart' => 'true',
 		);


### PR DESCRIPTION
Abandoned cart messages were not being delivered due to a bug in the code. The $cart parameter were mistakenly overridden causing the following functions to fail. This has been fixed.

Also this PR also improves formatting of the code and adds documentation to the abandoned cart functionality.