### PR TITLE
Bump the minimum supported WordPress version to 6.0

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -28,7 +28,7 @@
         <include-pattern>*\.php$</include-pattern>
     </rule>
 
-    <config name="minimum_supported_wp_version" value="5.0" />
+    <config name="minimum_supported_wp_version" value="6.0" />
 
     <rule ref="WordPress.WP.I18n">
         <properties>

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: sendsmaily, kaarel, tomabel, marispulk, tanely
 Tags: smaily, newsletter, email, mail, marketing
 Requires PHP: 7.0
-Requires at least: 5.0
+Requires at least: 6.0
 Tested up to: 6.7
 WC tested up to: 9.6.1
 Stable tag: 1.0.0


### PR DESCRIPTION
Increasing the minimum supported version to 6.0. This allows to use newer functionalities built into the WP regarding blocks development.