### PR TITLE
sandbox: Change mount folder name

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -25,7 +25,7 @@ services:
         # define( 'ALTERNATE_WP_CRON' , true );
     volumes:
     - wordpress:/var/www/html
-    - ./:/var/www/html/wp-content/plugins/smaily
+    - ./:/var/www/html/wp-content/plugins/smaily-wp-connect
 
   db:
     image: mysql:5.7


### PR DESCRIPTION
Changes mount folder name to smaily-wp-connect to reflect the correct plugin path.