### PR TITLE
Use plugin namespace while defiling cron events

### DIFF
--- a/includes/smaily-lifecycle.class.php
+++ b/includes/smaily-lifecycle.class.php
@@ -64,21 +64,21 @@ class Lifecycle {
 	 */
 	private function set_scheduled_actions() {
 		// Check if the daily sync action is already scheduled.
-		if ( ! wp_next_scheduled( 'smaily_cron_sync_subscribers' ) ) {
+		if ( ! wp_next_scheduled( 'smaily_wp_connect_cron_sync_subscribers' ) ) {
 			// Add Cron job to sync subscribers.
-			wp_schedule_event( time(), 'daily', 'smaily_cron_sync_subscribers' );
+			wp_schedule_event( time(), 'daily', 'smaily_wp_connect_cron_sync_subscribers' );
 		}
 
 		// Check if the abandoned cart status action is already scheduled.
-		if ( ! wp_next_scheduled( 'smaily_cron_abandoned_carts_status' ) ) {
+		if ( ! wp_next_scheduled( 'smaily_wp_connect_cron_abandoned_carts_status' ) ) {
 			// Schedule event to track abandoned statuses.
-			wp_schedule_event( time(), 'smaily_15_minutes', 'smaily_cron_abandoned_carts_status' );
+			wp_schedule_event( time(), 'smaily_wp_connect_15_minutes', 'smaily_wp_connect_cron_abandoned_carts_status' );
 		}
 
 		// Check if the abandoned cart email action is already scheduled.
-		if ( ! wp_next_scheduled( 'smaily_cron_abandoned_carts_email' ) ) {
+		if ( ! wp_next_scheduled( 'smaily_wp_connect_cron_abandoned_carts_email' ) ) {
 			// Schedule event to send emails.
-			wp_schedule_event( time(), 'smaily_15_minutes', 'smaily_cron_abandoned_carts_email' );
+			wp_schedule_event( time(), 'smaily_wp_connect_15_minutes', 'smaily_wp_connect_cron_abandoned_carts_email' );
 		}
 	}
 
@@ -131,9 +131,9 @@ class Lifecycle {
 		// Flush rewrite rules.
 		flush_rewrite_rules();
 		// Stop Cron.
-		wp_clear_scheduled_hook( 'smaily_cron_sync_subscribers' );
-		wp_clear_scheduled_hook( 'smaily_cron_abandoned_carts_email' );
-		wp_clear_scheduled_hook( 'smaily_cron_abandoned_carts_status' );
+		wp_clear_scheduled_hook( 'smaily_wp_connect_cron_sync_subscribers' );
+		wp_clear_scheduled_hook( 'smaily_wp_connect_cron_abandoned_carts_email' );
+		wp_clear_scheduled_hook( 'smaily_wp_connect_cron_abandoned_carts_status' );
 		$this->logger->info( 'Plugin deactivated' );
 	}
 

--- a/integrations/woocommerce/cron.class.php
+++ b/integrations/woocommerce/cron.class.php
@@ -46,11 +46,11 @@ class Cron {
 		// Register the custom schedule early
 		add_filter( 'cron_schedules', array( $this, 'smaily_cron_schedules' ) );
 		// Action hook for subscriber synchronization.
-		add_action( 'smaily_cron_sync_subscribers', array( $this, 'smaily_sync_subscribers' ) );
+		add_action( 'smaily_wp_connect_cron_sync_subscribers', array( $this, 'smaily_sync_subscribers' ) );
 		// Cron for updating abandoned cart statuses.
-		add_action( 'smaily_cron_abandoned_carts_status', array( $this, 'smaily_abandoned_carts_status' ) );
+		add_action( 'smaily_wp_connect_cron_abandoned_carts_status', array( $this, 'smaily_abandoned_carts_status' ) );
 		// Cron for sending abandoned cart emails.
-		add_action( 'smaily_cron_abandoned_carts_email', array( $this, 'smaily_abandoned_carts_email' ) );
+		add_action( 'smaily_wp_connect_cron_abandoned_carts_email', array( $this, 'smaily_abandoned_carts_email' ) );
 	}
 
 	/**
@@ -60,7 +60,7 @@ class Cron {
 	 * @return array $schedules Updated array.
 	 */
 	public function smaily_cron_schedules( $schedules ) {
-		$schedules['smaily_15_minutes'] = array(
+		$schedules['smaily_wp_connect_15_minutes'] = array(
 			'interval' => 900,
 			'display'  => esc_html__( 'In every 15 minutes', 'smaily' ),
 		);


### PR DESCRIPTION
The Smaily or WooCommerce plugin uses the same generic `smaily` namespace for defining cron schedules. In order to avoid potential conflicts with the Smaily for WooCommerce plugin we should use a more specific namespace.