### PR TITLE
Rename the plugin to Smaily Connect

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      WP_PLUGIN_NAME: smaily-wp-connect
+      WP_PLUGIN_NAME: smaily-connect
       WP_CLI_ALLOW_ROOT: true
     steps:
     - name: Checkout code

--- a/admin/css/smaily-admin.css
+++ b/admin/css/smaily-admin.css
@@ -1,14 +1,14 @@
-.smaily-wp-connect-admin-settings {
+.smaily-connect-admin-settings {
   font-family: Manrope;
   font-size: 13px;
   color: #1d2327;
   letter-spacing: 2%;
 }
 
-.smaily-wp-connect-admin-settings input[type="text"],
-.smaily-wp-connect-admin-settings input[type="password"],
-.smaily-wp-connect-admin-settings input[type="number"],
-.smaily-wp-connect-admin-settings select {
+.smaily-connect-admin-settings input[type="text"],
+.smaily-connect-admin-settings input[type="password"],
+.smaily-connect-admin-settings input[type="number"],
+.smaily-connect-admin-settings select {
   width: 300px;
 
   &:focus {
@@ -17,7 +17,7 @@
   }
 }
 
-.smaily-wp-connect-admin-settings select {
+.smaily-connect-admin-settings select {
   &:hover {
     color: #c21a4f;
   }
@@ -27,12 +27,12 @@
   }
 }
 
-.smaily-wp-connect-admin-tab-content option {
+.smaily-connect-admin-tab-content option {
   color: #1d2327;
   appearance: none;
 }
 
-.smaily-wp-connect-admin-settings input[type="checkbox"] {
+.smaily-connect-admin-settings input[type="checkbox"] {
   box-shadow: none;
 
   &:focus {
@@ -53,7 +53,7 @@
   }
 }
 
-.smaily-wp-connect-admin-settings a {
+.smaily-connect-admin-settings a {
   font-weight: 500;
   color: #e91e63;
 
@@ -66,11 +66,11 @@
   }
 }
 
-.smaily-wp-connect-admin-settings small {
+.smaily-connect-admin-settings small {
   display: block;
 }
 
-.smaily-wp-connect-admin-settings .button {
+.smaily-connect-admin-settings .button {
   border-radius: 5px;
   padding: 6px 12px;
   text-transform: capitalize;
@@ -92,12 +92,12 @@
   }
 }
 
-.smaily-wp-connect-admin-settings .button-primary {
+.smaily-connect-admin-settings .button-primary {
   background-color: #e91e63;
   border-color: #e91e63;
 }
 
-.smaily-wp-connect-admin-settings .button-secondary {
+.smaily-connect-admin-settings .button-secondary {
   color: #e91e63;
   border-color: #e91e63;
 
@@ -120,7 +120,7 @@
   }
 }
 
-.smaily-wp-connect-admin-tab {
+.smaily-connect-admin-tab {
   display: inline-block;
   padding: 0 20px;
   line-height: 66px;
@@ -130,49 +130,49 @@
   text-decoration: none;
 }
 
-.smaily-wp-connect-admin-tab-active {
+.smaily-connect-admin-tab-active {
   border-bottom: 1px solid #e91e63;
 }
 
-.smaily-wp-connect-admin-tab-content {
+.smaily-connect-admin-tab-content {
   margin-top: 20px;
   padding: 20px 30px;
   padding-bottom: 60px;
   background-color: white;
 }
 
-.smaily-wp-connect-admin-tab-content h2 {
+.smaily-connect-admin-tab-content h2 {
   font-size: 1.8em;
 }
 
 /* every new section except the first one */
-.smaily-wp-connect-admin-tab-content h2:not(:first-of-type) {
+.smaily-connect-admin-tab-content h2:not(:first-of-type) {
   margin-top: 40px;
 }
 
-.smaily-wp-connect-admin-tab-content h3 {
+.smaily-connect-admin-tab-content h3 {
   font-size: 1.2em;
 }
 
-.smaily-wp-connect-admin-tab-content section {
+.smaily-connect-admin-tab-content section {
   max-width: 560px;
 }
 
-.smaily-wp-connect-admin-tab-content ol li {
+.smaily-connect-admin-tab-content ol li {
   margin-bottom: 10px;
 }
 
-.smaily-wp-connect-subscriber-collection-list ::marker {
+.smaily-connect-subscriber-collection-list ::marker {
   font-size: 1.2em;
   font-weight: 600;
 }
 
-.smaily-wp-connect-admin-form-field {
+.smaily-connect-admin-form-field {
   padding-bottom: 10px;
   max-width: 310px;
 }
 
-.smaily-wp-connect-admin-tab-nav {
+.smaily-connect-admin-tab-nav {
   display: flex;
   align-items: center;
   background-color: white;
@@ -180,7 +180,7 @@
   padding-left: 30px;
 }
 
-.smaily-wp-connect-admin-tab-nav a {
+.smaily-connect-admin-tab-nav a {
   color: #1d2327;
   font-weight: 700;
 
@@ -190,7 +190,7 @@
   }
 }
 
-.smaily-wp-connect-admin-tab-logo {
+.smaily-connect-admin-tab-logo {
   padding-right: 20px;
 
   svg {
@@ -198,7 +198,7 @@
   }
 }
 
-#smaily-wp-connect-additional-information {
+#smaily-connect-additional-information {
   #user_gender_field {
     > span {
       display: flex;

--- a/admin/partials/smaily-admin-credentials.php
+++ b/admin/partials/smaily-admin-credentials.php
@@ -15,9 +15,9 @@ $connected = $subdomain && $username;
 
 <fieldset>
 	<input type="hidden" name="<?php echo esc_attr( \Smaily_WP_Connect\Includes\Options::API_CREDENTIALS_OPTION ); ?>[enabled]" value="<?php echo esc_attr( $connected ); ?>" />
-	<p class="smaily-wp-connect-admin-form-field">
+	<p class="smaily-connect-admin-form-field">
 		<label for="smaily_subdomain">
-			<?php esc_html_e( 'Smaily account subdomain', 'smaily-wp-connect' ); ?>*
+			<?php esc_html_e( 'Smaily account subdomain', 'smaily-connect' ); ?>*
 			<input
 				<?php if ( ! empty( $subdomain ) ) : ?>
 					disabled
@@ -36,16 +36,16 @@ $connected = $subdomain && $username;
 				/* translators: 1: example subdomain between strong tags */
 				esc_html__(
 					'For example "%1$s" from https://%1$s.sendsmaily.net/',
-					'smaily-wp-connect'
+					'smaily-connect'
 				),
 				'<strong>demo</strong>'
 			);
 			?>
 		</small>
 	</p>
-	<p class="smaily-wp-connect-admin-form-field">
+	<p class="smaily-connect-admin-form-field">
 		<label for="smaily_username">
-			<?php esc_html_e( 'API Username', 'smaily-wp-connect' ); ?>*
+			<?php esc_html_e( 'API Username', 'smaily-connect' ); ?>*
 			<input
 				<?php if ( ! empty( $username ) ) : ?>
 					disabled
@@ -59,9 +59,9 @@ $connected = $subdomain && $username;
 		</label>
 	</p>
 	<?php if ( ! $connected ) : ?>
-	<p class="smaily-wp-connect-admin-form-field">
+	<p class="smaily-connect-admin-form-field">
 		<label for="smaily_password">
-			<?php esc_html_e( 'API Password', 'smaily-wp-connect' ); ?>*
+			<?php esc_html_e( 'API Password', 'smaily-connect' ); ?>*
 			<input
 				<?php if ( ! empty( $password ) ) : ?>
 					disabled

--- a/admin/partials/smaily-admin-credentials.php
+++ b/admin/partials/smaily-admin-credentials.php
@@ -2,7 +2,7 @@
 /**
  * The credentials form for the Smaily API.
  *
- * @var Smaily_WP_Connect\Admin\Renderer $this
+ * @var Smaily_Connect\Admin\Renderer $this
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -14,7 +14,7 @@ $connected = $subdomain && $username;
 ?>
 
 <fieldset>
-	<input type="hidden" name="<?php echo esc_attr( \Smaily_WP_Connect\Includes\Options::API_CREDENTIALS_OPTION ); ?>[enabled]" value="<?php echo esc_attr( $connected ); ?>" />
+	<input type="hidden" name="<?php echo esc_attr( \Smaily_Connect\Includes\Options::API_CREDENTIALS_OPTION ); ?>[enabled]" value="<?php echo esc_attr( $connected ); ?>" />
 	<p class="smaily-connect-admin-form-field">
 		<label for="smaily_subdomain">
 			<?php esc_html_e( 'Smaily account subdomain', 'smaily-connect' ); ?>*
@@ -25,7 +25,7 @@ $connected = $subdomain && $username;
 				required
 				class="regular-text code"
 				id="smaily_subdomain"
-				name="<?php echo esc_attr( \Smaily_WP_Connect\Includes\Options::API_CREDENTIALS_OPTION ); ?>[subdomain]"
+				name="<?php echo esc_attr( \Smaily_Connect\Includes\Options::API_CREDENTIALS_OPTION ); ?>[subdomain]"
 				type="text"
 				value="<?php echo esc_attr( $subdomain ); ?>"
 			/>
@@ -52,7 +52,7 @@ $connected = $subdomain && $username;
 				<?php endif; ?>
 				required
 				class="regular-text code"
-				name="<?php echo esc_attr( \Smaily_WP_Connect\Includes\Options::API_CREDENTIALS_OPTION ); ?>[username]"
+				name="<?php echo esc_attr( \Smaily_Connect\Includes\Options::API_CREDENTIALS_OPTION ); ?>[username]"
 				type="text" id="smaily_username"
 				value="<?php echo esc_attr( $username ); ?>"
 			/>
@@ -69,7 +69,7 @@ $connected = $subdomain && $username;
 				required
 				class="regular-text code"
 				id="smaily_password"
-				name="<?php echo esc_attr( \Smaily_WP_Connect\Includes\Options::API_CREDENTIALS_OPTION ); ?>[password]"
+				name="<?php echo esc_attr( \Smaily_Connect\Includes\Options::API_CREDENTIALS_OPTION ); ?>[password]"
 				type="password"
 				value=""
 			/>

--- a/admin/partials/smaily-admin-page.php
+++ b/admin/partials/smaily-admin-page.php
@@ -19,10 +19,10 @@ $show_submit_button = isset( $tabs[ $current_tab ]['submit_button_text'] );
 settings_errors( 'smaily_wp_connect_messages' );
 
 ?>
-<div class="wrap smaily-wp-connect-admin-settings">
+<div class="wrap smaily-connect-admin-settings">
 	<form action="options.php" method="post">
-		<nav class="smaily-wp-connect-admin-tab-nav">
-			<div class="smaily-wp-connect-admin-tab-logo">
+		<nav class="smaily-connect-admin-tab-nav">
+			<div class="smaily-connect-admin-tab-logo">
 				<svg width="31" height="31" viewBox="0 0 31 31" fill="none" xmlns="http://www.w3.org/2000/svg">
 					<g clip-path="url(#clip0_704_436)">
 						<path d="M5.17383 30.9999L22.7476 30.9893L27.6756 27.451V4.13684H5.17383V30.9999Z" fill="white"/>
@@ -37,14 +37,14 @@ settings_errors( 'smaily_wp_connect_messages' );
 			</div>
 			<?php foreach ( $tabs as $tab => $options ) : ?>
 				<a
-					class="smaily-wp-connect-admin-tab <?php echo $tab === $current_tab ? 'smaily-wp-connect-admin-tab-active' : ''; ?>"
+					class="smaily-connect-admin-tab <?php echo $tab === $current_tab ? 'smaily-connect-admin-tab-active' : ''; ?>"
 					href="<?php echo esc_url( $options['url'] ); ?>"
 				>
 				<?php echo esc_html( $options['title'] ); ?>
 				</a>
 			<?php endforeach ?>
 		</nav>
-		<div class="smaily-wp-connect-admin-tab-content">
+		<div class="smaily-connect-admin-tab-content">
 			<?php
 				settings_fields( $tabs[ $current_tab ]['option_group'] );
 				do_settings_sections( $tabs[ $current_tab ]['page'] );

--- a/admin/partials/smaily-admin-page.php
+++ b/admin/partials/smaily-admin-page.php
@@ -16,7 +16,7 @@ if ( isset( $_GET['tab'] ) ) {
 	}
 }
 $show_submit_button = isset( $tabs[ $current_tab ]['submit_button_text'] );
-settings_errors( 'smaily_wp_connect_messages' );
+settings_errors( 'smaily_connect_messages' );
 
 ?>
 <div class="wrap smaily-connect-admin-settings">

--- a/admin/partials/smaily-admin-page.php
+++ b/admin/partials/smaily-admin-page.php
@@ -2,7 +2,7 @@
 /**
  * Smaily admin page template.
  *
- * @var Smaily_WP_Connect\Admin $this
+ * @var Smaily_Connect\Admin $this
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/admin/partials/smaily-admin-woocommerce-abandoned-cart.php
+++ b/admin/partials/smaily-admin-woocommerce-abandoned-cart.php
@@ -12,18 +12,18 @@ defined( 'ABSPATH' ) || exit;
 $mandatory   = array( 'user_email', 'store_url', 'language' );
 $sync_fields = get_option( Options::ABANDONED_CART_FIELDS_OPTION, Options::ABANDONED_CART_DEFAULT_FIELDS );
 $labels      = array(
-	'user_email'          => __( 'Email', 'smaily-wp-connect' ),
-	'store_url'           => __( 'Store URL', 'smaily-wp-connect' ),
-	'first_name'          => __( 'Customer First Name', 'smaily-wp-connect' ),
-	'last_name'           => __( 'Customer Last Name', 'smaily-wp-connect' ),
-	'language'            => __( 'Language', 'smaily-wp-connect' ),
-	'product_name'        => __( 'Product Name', 'smaily-wp-connect' ),
-	'product_description' => __( 'Product Description', 'smaily-wp-connect' ),
-	'product_sku'         => __( 'Product SKU', 'smaily-wp-connect' ),
-	'product_quantity'    => __( 'Product Quantity', 'smaily-wp-connect' ),
-	'product_base_price'  => __( 'Product Base Price', 'smaily-wp-connect' ),
-	'product_price'       => __( 'Product Price', 'smaily-wp-connect' ),
-	'product_image_url'   => __( 'Product Image', 'smaily-wp-connect' ),
+	'user_email'          => __( 'Email', 'smaily-connect' ),
+	'store_url'           => __( 'Store URL', 'smaily-connect' ),
+	'first_name'          => __( 'Customer First Name', 'smaily-connect' ),
+	'last_name'           => __( 'Customer Last Name', 'smaily-connect' ),
+	'language'            => __( 'Language', 'smaily-connect' ),
+	'product_name'        => __( 'Product Name', 'smaily-connect' ),
+	'product_description' => __( 'Product Description', 'smaily-connect' ),
+	'product_sku'         => __( 'Product SKU', 'smaily-connect' ),
+	'product_quantity'    => __( 'Product Quantity', 'smaily-connect' ),
+	'product_base_price'  => __( 'Product Base Price', 'smaily-connect' ),
+	'product_price'       => __( 'Product Price', 'smaily-connect' ),
+	'product_image_url'   => __( 'Product Image', 'smaily-connect' ),
 );
 
 ?>
@@ -48,7 +48,7 @@ $labels      = array(
 		<?php
 		esc_html_e(
 			'Select extra fields you wish to send to Smaily.',
-			'smaily-wp-connect'
+			'smaily-connect'
 		);
 		?>
 	</small>

--- a/admin/partials/smaily-admin-woocommerce-abandoned-cart.php
+++ b/admin/partials/smaily-admin-woocommerce-abandoned-cart.php
@@ -2,10 +2,10 @@
 /**
  * WooCommerce abandoned cart fields settings.
  *
- * @var Smaily_WP_Connect\Admin\Renderer $this
+ * @var Smaily_Connect\Admin\Renderer $this
  */
 
-use Smaily_WP_Connect\Includes\Options;
+use Smaily_Connect\Includes\Options;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/admin/partials/smaily-admin-woocommerce-subscriber-sync.php
+++ b/admin/partials/smaily-admin-woocommerce-subscriber-sync.php
@@ -11,19 +11,19 @@ defined( 'ABSPATH' ) || exit;
 $mandatory   = array( 'user_email', 'store_url', 'language' );
 $sync_fields = get_option( Options::SUBSCRIBER_SYNC_FIELDS_OPTION, Options::SUBSCRIBER_SYNC_DEFAULT_FIELDS );
 $labels      = array(
-	'customer_group'   => __( 'Customer Group', 'smaily-wp-connect' ),
-	'customer_id'      => __( 'Customer ID', 'smaily-wp-connect' ),
-	'first_name'       => __( 'First name', 'smaily-wp-connect' ),
-	'first_registered' => __( 'First Registered', 'smaily-wp-connect' ),
-	'last_name'        => __( 'Last name', 'smaily-wp-connect' ),
-	'language'         => __( 'Language', 'smaily-wp-connect' ),
-	'nickname'         => __( 'Nickname', 'smaily-wp-connect' ),
-	'site_title'       => __( 'Site Title', 'smaily-wp-connect' ),
-	'store_url'        => __( 'Store URL', 'smaily-wp-connect' ),
-	'user_dob'         => __( 'Birthday', 'smaily-wp-connect' ),
-	'user_email'       => __( 'Email', 'smaily-wp-connect' ),
-	'user_gender'      => __( 'Gender', 'smaily-wp-connect' ),
-	'user_phone'       => __( 'Phone', 'smaily-wp-connect' ),
+	'customer_group'   => __( 'Customer Group', 'smaily-connect' ),
+	'customer_id'      => __( 'Customer ID', 'smaily-connect' ),
+	'first_name'       => __( 'First name', 'smaily-connect' ),
+	'first_registered' => __( 'First Registered', 'smaily-connect' ),
+	'last_name'        => __( 'Last name', 'smaily-connect' ),
+	'language'         => __( 'Language', 'smaily-connect' ),
+	'nickname'         => __( 'Nickname', 'smaily-connect' ),
+	'site_title'       => __( 'Site Title', 'smaily-connect' ),
+	'store_url'        => __( 'Store URL', 'smaily-connect' ),
+	'user_dob'         => __( 'Birthday', 'smaily-connect' ),
+	'user_email'       => __( 'Email', 'smaily-connect' ),
+	'user_gender'      => __( 'Gender', 'smaily-connect' ),
+	'user_phone'       => __( 'Phone', 'smaily-connect' ),
 );
 
 ?>
@@ -48,7 +48,7 @@ $labels      = array(
 		<?php
 		esc_html_e(
 			'Select extra fields you wish to send to Smaily.',
-			'smaily-wp-connect'
+			'smaily-connect'
 		);
 		?>
 	</small>

--- a/admin/partials/smaily-admin-woocommerce-subscriber-sync.php
+++ b/admin/partials/smaily-admin-woocommerce-subscriber-sync.php
@@ -2,10 +2,10 @@
 /**
  * WooCommerce subscriber sync fields.
  *
- * @var Smaily_WP_Connect\Admin\Renderer $this
+ * @var Smaily_Connect\Admin\Renderer $this
  */
 
-use Smaily_WP_Connect\Includes\Options;
+use Smaily_Connect\Includes\Options;
 
 defined( 'ABSPATH' ) || exit;
 $mandatory   = array( 'user_email', 'store_url', 'language' );

--- a/admin/smaily-admin-renderer.class.php
+++ b/admin/smaily-admin-renderer.class.php
@@ -210,7 +210,7 @@ class Renderer {
 	 * @return void
 	 */
 	public function render_credentials_fields() {
-		include_once SMAILY_WP_CONNECT_PLUGIN_PATH . '/admin/partials/smaily-admin-credentials.php';
+		include_once SMAILY_CONNECT_PLUGIN_PATH . '/admin/partials/smaily-admin-credentials.php';
 	}
 
 	/**
@@ -219,7 +219,7 @@ class Renderer {
 	 * @return void
 	 */
 	public function render_sync_additional_fields() {
-		include_once SMAILY_WP_CONNECT_PLUGIN_PATH . '/admin/partials/smaily-admin-woocommerce-subscriber-sync.php';
+		include_once SMAILY_CONNECT_PLUGIN_PATH . '/admin/partials/smaily-admin-woocommerce-subscriber-sync.php';
 	}
 
 	/**
@@ -313,7 +313,7 @@ class Renderer {
 	 * @return void
 	 */
 	public function render_abandoned_additional_fields() {
-		include_once SMAILY_WP_CONNECT_PLUGIN_PATH . '/admin/partials/smaily-admin-woocommerce-abandoned-cart.php';
+		include_once SMAILY_CONNECT_PLUGIN_PATH . '/admin/partials/smaily-admin-woocommerce-abandoned-cart.php';
 	}
 
 	/**

--- a/admin/smaily-admin-renderer.class.php
+++ b/admin/smaily-admin-renderer.class.php
@@ -105,7 +105,7 @@ class Renderer {
 									'You can add the %1$s shortcode to any page or post.',
 									'smaily-connect'
 								),
-								'<span class="regular-text code">[smaily_wp_connect_newsletter_form]</span>'
+								'<span class="regular-text code">[smaily_connect_newsletter_form]</span>'
 							);
 						?>
 						</p>

--- a/admin/smaily-admin-renderer.class.php
+++ b/admin/smaily-admin-renderer.class.php
@@ -37,18 +37,18 @@ class Renderer {
 					<?php
 					esc_html_e(
 						'There seems to be a problem with your connection to Smaily. Please revalidate your credentials!',
-						'smaily-wp-connect'
+						'smaily-connect'
 					);
 					?>
 				</p>
 			</div>
 		<?php endif; ?>
-		<section class="smaily-wp-connect-connection-section-header">
+		<section class="smaily-connect-connection-section-header">
 			<p>
-				<?php esc_html_e( "Start by connecting your Smaily account with your website. Go to your Smaily account's settings integrations tab and create a new API user. Then copy the account subdomain, API username and API password below.", 'smaily-wp-connect' ); ?>
+				<?php esc_html_e( "Start by connecting your Smaily account with your website. Go to your Smaily account's settings integrations tab and create a new API user. Then copy the account subdomain, API username and API password below.", 'smaily-connect' ); ?>
 			</p>
 			<a href="https://smaily.com/help/api/general/create-api-user/" target="_blank">
-				<?php esc_html_e( 'How to create API credentials?', 'smaily-wp-connect' ); ?>
+				<?php esc_html_e( 'How to create API credentials?', 'smaily-connect' ); ?>
 			</a>
 		</section>
 		<?php
@@ -63,18 +63,18 @@ class Renderer {
 		?>
 		<section>
 			<p>
-				<?php esc_html_e( 'You can use the following methods to collect subscribers:', 'smaily-wp-connect' ); ?>
-				<ol class="smaily-wp-connect-subscriber-collection-list">
+				<?php esc_html_e( 'You can use the following methods to collect subscribers:', 'smaily-connect' ); ?>
+				<ol class="smaily-connect-subscriber-collection-list">
 					<?php if ( wp_is_block_theme() ) : ?>
 					<li>
 						<h3>
-							<?php esc_html_e( 'Use the Smaily subscription form block.', 'smaily-wp-connect' ); ?>
+							<?php esc_html_e( 'Use the Smaily subscription form block.', 'smaily-connect' ); ?>
 						</h3>
 						<p>
 							<?php
 								esc_html_e(
 									'Add the Smaily Sign-Up Form block to any page or post. The block is available in the block editor.',
-									'smaily-wp-connect'
+									'smaily-connect'
 								);
 							?>
 							<br>
@@ -83,19 +83,19 @@ class Renderer {
 					<?php else : ?>
 					<li>
 						<h3>
-							<?php esc_html_e( 'Use the Smaily subscription form widget.', 'smaily-wp-connect' ); ?>
+							<?php esc_html_e( 'Use the Smaily subscription form widget.', 'smaily-connect' ); ?>
 						</h3>
 						<p>
-							<?php esc_html_e( 'You can add the widget to your website from the widgets page.', 'smaily-wp-connect' ); ?>
+							<?php esc_html_e( 'You can add the widget to your website from the widgets page.', 'smaily-connect' ); ?>
 						</p>
 						<a href="<?php echo esc_url( admin_url( 'widgets.php' ) ); ?>">
-							<?php esc_html_e( 'Set up the Smaily Classic Subscription widget.', 'smaily-wp-connect' ); ?>
+							<?php esc_html_e( 'Set up the Smaily Classic Subscription widget.', 'smaily-connect' ); ?>
 						</a>
 					</li>
 					<?php endif; ?>
 					<li>
 						<h3>
-							<?php esc_html_e( 'Use the Smaily subscription form shortcode.', 'smaily-wp-connect' ); ?>
+							<?php esc_html_e( 'Use the Smaily subscription form shortcode.', 'smaily-connect' ); ?>
 						</h3>
 						<p>
 						<?php
@@ -103,59 +103,59 @@ class Renderer {
 								/* translators: 1: example subdomain between strong tags */
 								esc_html__(
 									'You can add the %1$s shortcode to any page or post.',
-									'smaily-wp-connect'
+									'smaily-connect'
 								),
 								'<span class="regular-text code">[smaily_wp_connect_newsletter_form]</span>'
 							);
 						?>
 						</p>
 						<?php
-							$anchor = esc_html__( 'read the detailed guide', 'smaily-wp-connect' );
-							$domain = esc_url( __( 'https://smaily.com/help/how-to/ecommerce-integrations/smaily-wp-connect', 'smaily-wp-connect' ) );
+							$anchor = esc_html__( 'read the detailed guide', 'smaily-connect' );
+							$domain = esc_url( __( 'https://smaily.com/help/how-to/ecommerce-integrations/smaily-connect', 'smaily-connect' ) );
 							$link   = sprintf( '<a href="%s" target="_blank">%s</a>', $domain, $anchor );
 							echo sprintf(
 								/* translators: 1: link to setting up block component guide */
-								esc_html__( 'For more configuration options %1$s.', 'smaily-wp-connect' ),
+								esc_html__( 'For more configuration options %1$s.', 'smaily-connect' ),
 								wp_kses_post( $link )
 							);
 						?>
 					</li>
 					<li>
 						<h3>
-							<?php esc_html_e( 'Build your own from component.', 'smaily-wp-connect' ); ?>
+							<?php esc_html_e( 'Build your own from component.', 'smaily-connect' ); ?>
 						</h3>
 						<p>
 							<?php
 								esc_html_e(
 									"Create a custom HTML form for maximum flexibility and advanced functionality. While this requires more technical knowledge, it gives you complete control over the form's appearance and behavior.",
-									'smaily-wp-connect'
+									'smaily-connect'
 								);
 							?>
 						</p>
 						<?php
-							$anchor = esc_html__( 'here', 'smaily-wp-connect' );
-							$domain = esc_url( __( 'https://smaily.com/help/how-to/forms-subscriptions/an-example-of-a-signup-form/', 'smaily-wp-connect' ) );
+							$anchor = esc_html__( 'here', 'smaily-connect' );
+							$domain = esc_url( __( 'https://smaily.com/help/how-to/forms-subscriptions/an-example-of-a-signup-form/', 'smaily-connect' ) );
 							$link   = sprintf( '<a href="%s" target="_blank">%s</a>', $domain, $anchor );
 							echo sprintf(
 								/* translators: 1: link to custom HTML guide */
-								esc_html__( 'You can view the example form %1$s.', 'smaily-wp-connect' ),
+								esc_html__( 'You can view the example form %1$s.', 'smaily-connect' ),
 								wp_kses_post( $link )
 							);
 						?>
 					</li>
 					<li>
 						<h3>
-							<?php esc_html_e( 'Use the Contact Form 7 form builder and Smaily connector.', 'smaily-wp-connect' ); ?>
+							<?php esc_html_e( 'Use the Contact Form 7 form builder and Smaily connector.', 'smaily-connect' ); ?>
 						</h3>
 						<p>
 							<?php
-								esc_html_e( 'You can also use Contact Form 7 form builder to create custom forms and connect them to your Smaily account.', 'smaily-wp-connect' );
+								esc_html_e( 'You can also use Contact Form 7 form builder to create custom forms and connect them to your Smaily account.', 'smaily-connect' );
 							?>
 						</p>
 						<?php if ( Helper::is_cf7_active() ) : ?>
 							<p>
 								<a href="<?php echo esc_url( menu_page_url( 'wpcf7', false ) ); ?>">
-									<?php esc_html_e( 'Enable Smaily Opt-In under the form settings.', 'smaily-wp-connect' ); ?>
+									<?php esc_html_e( 'Enable Smaily Opt-In under the form settings.', 'smaily-connect' ); ?>
 								</a>
 							</p>
 						<?php else : ?>
@@ -163,7 +163,7 @@ class Renderer {
 								<?php
 									esc_html_e(
 										'Please install the Contact Form 7 plugin to use this integration.',
-										'smaily-wp-connect'
+										'smaily-connect'
 									);
 								?>
 							</p>
@@ -184,19 +184,19 @@ class Renderer {
 		?>
 		<section>
 			<p>
-				<?php esc_html_e( 'Smaily integration with your WooCommerce store allows you to:', 'smaily-wp-connect' ); ?>
+				<?php esc_html_e( 'Smaily integration with your WooCommerce store allows you to:', 'smaily-connect' ); ?>
 				<ol>
 					<li>
-						<?php esc_html_e( 'Automatically Synchronize subscribers using the daily Subscriber Synchronization.', 'smaily-wp-connect' ); ?>
+						<?php esc_html_e( 'Automatically Synchronize subscribers using the daily Subscriber Synchronization.', 'smaily-connect' ); ?>
 					</li>
 					<li>
-						<?php esc_html_e( 'Send Abandoned Cart reminder emails to store customers.', 'smaily-wp-connect' ); ?>
+						<?php esc_html_e( 'Send Abandoned Cart reminder emails to store customers.', 'smaily-connect' ); ?>
 					</li>
 					<li>
-						<?php esc_html_e( 'Collect subscribers during checkout.', 'smaily-wp-connect' ); ?>
+						<?php esc_html_e( 'Collect subscribers during checkout.', 'smaily-connect' ); ?>
 					</li>
 					<li>
-						<?php esc_html_e( 'Generate RSS-feeds of your products that enables product import into Smaily drag-and-drop templates.', 'smaily-wp-connect' ); ?>
+						<?php esc_html_e( 'Generate RSS-feeds of your products that enables product import into Smaily drag-and-drop templates.', 'smaily-connect' ); ?>
 					</li>
 				</ol>
 			</p>
@@ -234,7 +234,7 @@ class Renderer {
 				<?php
 					esc_html_e(
 						'Subscriber Synchronization allows you Synchronize newsletter subscribers and their information directly to Smaily',
-						'smaily-wp-connect'
+						'smaily-connect'
 					);
 				?>
 			</p>
@@ -254,7 +254,7 @@ class Renderer {
 				<?php
 				esc_html_e(
 					'Abandoned Cart allows you to send automated emails to customers who have left their shopping cart.',
-					'smaily-wp-connect'
+					'smaily-connect'
 				);
 				?>
 			</p>
@@ -283,7 +283,7 @@ class Renderer {
 					value="1"
 					<?php checked( $enabled, true ); ?>
 				/>
-				<?php esc_html_e( 'Enabled', 'smaily-wp-connect' ); ?>
+				<?php esc_html_e( 'Enabled', 'smaily-connect' ); ?>
 			</label>
 		</fieldset>
 		<fieldset>
@@ -299,7 +299,7 @@ class Renderer {
 					<?php endforeach; ?>
 				<?php else : ?>
 					<option value="">
-						<?php esc_html_e( 'No automations created', 'smaily-wp-connect' ); ?>
+						<?php esc_html_e( 'No automations created', 'smaily-connect' ); ?>
 					</option>
 				<?php endif; ?>
 			</select>
@@ -328,7 +328,7 @@ class Renderer {
 				<?php
 				esc_html_e(
 					'Customers can subscribe by checking "subscribe to newsletter" checkbox on checkout page.',
-					'smaily-wp-connect'
+					'smaily-connect'
 				);
 				?>
 			</p>
@@ -348,12 +348,12 @@ class Renderer {
 				<?php
 				esc_html_e(
 					'Smaily RSS feed allows you insert product feeds to email templates.',
-					'smaily-wp-connect'
+					'smaily-connect'
 				);
 				?>
 			</p>
 			<a href="https://smaily.com/help/user-manual/templates/adding-rss-feed-to-template/" target="_blank">
-				<?php esc_html_e( 'How to add RSS feed to template?', 'smaily-wp-connect' ); ?>
+				<?php esc_html_e( 'How to add RSS feed to template?', 'smaily-connect' ); ?>
 			</a>
 		</section>
 		<?php
@@ -380,7 +380,7 @@ class Renderer {
 				<?php
 				esc_html_e(
 					"Copy this URL into your template editor's RSS block, to receive RSS-feed.",
-					'smaily-wp-connect'
+					'smaily-connect'
 				);
 				?>
 			</small>
@@ -390,7 +390,7 @@ class Renderer {
 				class="button button-secondary"
 				id="smaily-rss-feed-url-copy"
 			>
-				<?php esc_html_e( 'Copy', 'smaily-wp-connect' ); ?>
+				<?php esc_html_e( 'Copy', 'smaily-connect' ); ?>
 			</button>
 			<span
 				id="smaily-rss-feed-url-copy-icon"
@@ -423,7 +423,7 @@ class Renderer {
 					value="1"
 					<?php checked( $value, true ); ?>
 				/>
-				<?php esc_html_e( 'Enabled', 'smaily-wp-connect' ); ?>
+				<?php esc_html_e( 'Enabled', 'smaily-connect' ); ?>
 			</label>
 			<?php if ( ! empty( $help ) ) : ?>
 				<small class="form-text text-muted">

--- a/admin/smaily-admin-renderer.class.php
+++ b/admin/smaily-admin-renderer.class.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Smaily_WP_Connect\Admin;
+namespace Smaily_Connect\Admin;
 
-use Smaily_WP_Connect\Includes\Helper;
-use Smaily_WP_Connect\Includes\Options;
-use Smaily_WP_Connect\Includes\Smaily_Client;
-use Smaily_WP_Connect\Integrations\WooCommerce\Rss;
+use Smaily_Connect\Includes\Helper;
+use Smaily_Connect\Includes\Options;
+use Smaily_Connect\Includes\Smaily_Client;
+use Smaily_Connect\Integrations\WooCommerce\Rss;
 
 class Renderer {
 	/**

--- a/admin/smaily-admin-sanitizer.class.php
+++ b/admin/smaily-admin-sanitizer.class.php
@@ -17,7 +17,7 @@ class Sanitizer {
 
 		if ( $enabled === true && $autoresponder_id === '' ) {
 			add_settings_error(
-				'smaily_wp_connect_messages',
+				'smaily_connect_messages',
 				'no_autoresponder_for_abandoned_cart',
 				__( 'Please select autoresponder for abandoned cart automation.', 'smaily-connect' ),
 				'error'
@@ -41,7 +41,7 @@ class Sanitizer {
 		// Disconnect.
 		if ( isset( $input['enabled'] ) && $input['enabled'] === '1' ) {
 			add_settings_error(
-				'smaily_wp_connect_messages',
+				'smaily_connect_messages',
 				'credentials_validated',
 				'API credentials disconnected!',
 				'success'
@@ -67,7 +67,7 @@ class Sanitizer {
 		if ( ! empty( $validation_errors ) ) {
 			$validation_errors = implode( '<br>', $validation_errors );
 			add_settings_error(
-				'smaily_wp_connect_messages',
+				'smaily_connect_messages',
 				'invalid_api_credentials',
 				$validation_errors,
 				'error'

--- a/admin/smaily-admin-sanitizer.class.php
+++ b/admin/smaily-admin-sanitizer.class.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Smaily_WP_Connect\Admin;
+namespace Smaily_Connect\Admin;
 
-use Smaily_WP_Connect\Includes\Options;
+use Smaily_Connect\Includes\Options;
 
 class Sanitizer {
 	/**

--- a/admin/smaily-admin-sanitizer.class.php
+++ b/admin/smaily-admin-sanitizer.class.php
@@ -19,7 +19,7 @@ class Sanitizer {
 			add_settings_error(
 				'smaily_wp_connect_messages',
 				'no_autoresponder_for_abandoned_cart',
-				__( 'Please select autoresponder for abandoned cart automation.', 'smaily-wp-connect' ),
+				__( 'Please select autoresponder for abandoned cart automation.', 'smaily-connect' ),
 				'error'
 			);
 
@@ -56,13 +56,13 @@ class Sanitizer {
 
 		$validation_errors = array();
 		if ( empty( trim( $input['subdomain'] ) ) ) {
-			$validation_errors[] = __( 'Please enter subdomain!', 'smaily-wp-connect' );
+			$validation_errors[] = __( 'Please enter subdomain!', 'smaily-connect' );
 		}
 		if ( empty( trim( $input['username'] ) ) ) {
-			$validation_errors[] = __( 'Please enter username!', 'smaily-wp-connect' );
+			$validation_errors[] = __( 'Please enter username!', 'smaily-connect' );
 		}
 		if ( empty( trim( $input['password'] ) ) ) {
-			$validation_errors[] = __( 'Please enter password!', 'smaily-wp-connect' );
+			$validation_errors[] = __( 'Please enter password!', 'smaily-connect' );
 		}
 		if ( ! empty( $validation_errors ) ) {
 			$validation_errors = implode( '<br>', $validation_errors );

--- a/admin/smaily-admin-settings.class.php
+++ b/admin/smaily-admin-settings.class.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Smaily_WP_Connect\Admin;
+namespace Smaily_Connect\Admin;
 
-use Smaily_WP_Connect\Includes\Helper;
-use Smaily_WP_Connect\Includes\Options;
-use Smaily_WP_Connect\Integrations\WooCommerce\Rss;
+use Smaily_Connect\Includes\Helper;
+use Smaily_Connect\Includes\Options;
+use Smaily_Connect\Integrations\WooCommerce\Rss;
 
 class Settings {
 	/**

--- a/admin/smaily-admin-settings.class.php
+++ b/admin/smaily-admin-settings.class.php
@@ -59,14 +59,14 @@ class Settings {
 
 		add_settings_section(
 			$section,
-			__( 'Connection', 'smaily-wp-connect' ),
+			__( 'Connection', 'smaily-connect' ),
 			array( $this->renderer, 'render_connection_section_header' ),
 			$page
 		);
 
 		add_settings_field(
 			Options::API_CREDENTIALS_OPTION,
-			__( 'Credentials', 'smaily-wp-connect' ),
+			__( 'Credentials', 'smaily-connect' ),
 			array( $this->renderer, 'render_credentials_fields' ),
 			$page,
 			$section
@@ -80,7 +80,7 @@ class Settings {
 	public function register_tutorial_tab_settings( $option_group, $page ) {
 		add_settings_section(
 			'smaily_wp_connect_subscriber_collection_section',
-			__( 'Setting up subscriber collection', 'smaily-wp-connect' ),
+			__( 'Setting up subscriber collection', 'smaily-connect' ),
 			array( $this->renderer, 'render_tutorial_subscriber_collection_section' ),
 			$page
 		);
@@ -88,7 +88,7 @@ class Settings {
 		if ( Helper::is_woocommerce_active() ) {
 			add_settings_section(
 				'smaily_wp_connect_woocommerce_section',
-				__( 'WooCommerce Integration', 'smaily-wp-connect' ),
+				__( 'WooCommerce Integration', 'smaily-connect' ),
 				array( $this->renderer, 'render_tutorial_woocommerce_section' ),
 				$page
 			);
@@ -125,26 +125,26 @@ class Settings {
 
 		add_settings_section(
 			$subscriber_sync_section,
-			__( 'Daily Automatic Subscriber Synchronization', 'smaily-wp-connect' ),
+			__( 'Daily Automatic Subscriber Synchronization', 'smaily-connect' ),
 			array( $this->renderer, 'render_subscriber_sync_section_header' ),
 			$page
 		);
 
 		add_settings_field(
 			Options::SUBSCRIBER_SYNC_ENABLED_OPTION,
-			__( 'Enable Subscriber Synchronization', 'smaily-wp-connect' ),
+			__( 'Enable Subscriber Synchronization', 'smaily-connect' ),
 			array( $this->renderer, 'render_enabled_field' ),
 			$page,
 			$subscriber_sync_section,
 			array(
 				'option_name' => Options::SUBSCRIBER_SYNC_ENABLED_OPTION,
-				'help'        => __( 'The cron job will run once a day.', 'smaily-wp-connect' ),
+				'help'        => __( 'The cron job will run once a day.', 'smaily-connect' ),
 			)
 		);
 
 		add_settings_field(
 			Options::SUBSCRIBER_SYNC_FIELDS_OPTION,
-			__( 'Additional Fields', 'smaily-wp-connect' ),
+			__( 'Additional Fields', 'smaily-connect' ),
 			array( $this->renderer, 'render_sync_additional_fields' ),
 			$page,
 			$subscriber_sync_section
@@ -183,14 +183,14 @@ class Settings {
 
 		add_settings_section(
 			$checkout_subscription_section,
-			__( 'Newsletter Subscription On Checkout', 'smaily-wp-connect' ),
+			__( 'Newsletter Subscription On Checkout', 'smaily-connect' ),
 			array( $this->renderer, 'render_checkout_subscription_section_header' ),
 			$page
 		);
 
 		add_settings_field(
 			Options::CHECKOUT_SUBSCRIPTION_ENABLED_OPTION,
-			__( 'Enable Checkout Subscription', 'smaily-wp-connect' ),
+			__( 'Enable Checkout Subscription', 'smaily-connect' ),
 			array( $this->renderer, 'render_enabled_field' ),
 			$page,
 			$checkout_subscription_section,
@@ -201,7 +201,7 @@ class Settings {
 
 		add_settings_field(
 			Options::CHECKOUT_SUBSCRIPTION_POSITION_OPTION,
-			__( 'Position', 'smaily-wp-connect' ),
+			__( 'Position', 'smaily-connect' ),
 			array( $this->renderer, 'render_select_field' ),
 			$page,
 			$checkout_subscription_section,
@@ -213,7 +213,7 @@ class Settings {
 
 		add_settings_field(
 			Options::CHECKOUT_SUBSCRIPTION_LOCATION_OPTION,
-			__( 'Location', 'smaily-wp-connect' ),
+			__( 'Location', 'smaily-connect' ),
 			array( $this->renderer, 'render_select_field' ),
 			$page,
 			$checkout_subscription_section,
@@ -267,14 +267,14 @@ class Settings {
 
 		add_settings_section(
 			$abandoned_cart_section,
-			__( 'Abandoned Cart Reminder Emails', 'smaily-wp-connect' ),
+			__( 'Abandoned Cart Reminder Emails', 'smaily-connect' ),
 			array( $this->renderer, 'render_abandoned_cart_section_header' ),
 			$page
 		);
 
 		add_settings_field(
 			Options::ABANDONED_CART_STATUS_OPTION,
-			__( 'Enable Abandoned Cart', 'smaily-wp-connect' ),
+			__( 'Enable Abandoned Cart', 'smaily-connect' ),
 			array( $this->renderer, 'render_abandoned_cart_status_field' ),
 			$page,
 			$abandoned_cart_section
@@ -282,20 +282,20 @@ class Settings {
 
 		add_settings_field(
 			Options::ABANDONED_CART_CUTOFF_OPTION,
-			__( 'Cart cutoff time (minutes)', 'smaily-wp-connect' ),
+			__( 'Cart cutoff time (minutes)', 'smaily-connect' ),
 			array( $this->renderer, 'render_number_field' ),
 			$page,
 			$abandoned_cart_section,
 			array(
 				'option_name' => Options::ABANDONED_CART_CUTOFF_OPTION,
 				'min'         => Options::ABANDONED_CART_DEFAULT_CUTOFF,
-				'help'        => __( 'Time in minutes after which the cart is considered abandoned. Minimum 10 minutes.', 'smaily-wp-connect' ),
+				'help'        => __( 'Time in minutes after which the cart is considered abandoned. Minimum 10 minutes.', 'smaily-connect' ),
 			)
 		);
 
 		add_settings_field(
 			Options::ABANDONED_CART_FIELDS_OPTION,
-			__( 'Additional Fields', 'smaily-wp-connect' ),
+			__( 'Additional Fields', 'smaily-connect' ),
 			array( $this->renderer, 'render_abandoned_additional_fields' ),
 			$page,
 			$abandoned_cart_section
@@ -367,14 +367,14 @@ class Settings {
 
 		add_settings_section(
 			$rss_section,
-			__( 'Smaily RSS feed', 'smaily-wp-connect' ),
+			__( 'Smaily RSS feed', 'smaily-connect' ),
 			array( $this->renderer, 'render_rss_section_header' ),
 			$page
 		);
 
 		add_settings_field(
 			Options::RSS_LIMIT_OPTION,
-			__( 'Limit', 'smaily-wp-connect' ),
+			__( 'Limit', 'smaily-connect' ),
 			array( $this->renderer, 'render_number_field' ),
 			$page,
 			$rss_section,
@@ -382,7 +382,7 @@ class Settings {
 				'option_name' => Options::RSS_LIMIT_OPTION,
 				'min'         => 1,
 				'max'         => 250,
-				'help'        => __( 'Limit how many products you will add to your field. Maximum 250.', 'smaily-wp-connect' ),
+				'help'        => __( 'Limit how many products you will add to your field. Maximum 250.', 'smaily-connect' ),
 				'class'       => 'smaily-rss-options',
 				'id'          => 'smaily-rss-limit',
 			)
@@ -399,16 +399,16 @@ class Settings {
 
 		add_settings_field(
 			Options::RSS_CATEGORY_OPTION,
-			__( 'Product Category', 'smaily-wp-connect' ),
+			__( 'Product Category', 'smaily-connect' ),
 			array( $this->renderer, 'render_select_field' ),
 			$page,
 			$rss_section,
 			array(
 				'option_name' => Options::RSS_CATEGORY_OPTION,
 				'options'     => array(
-					'' => __( 'All', 'smaily-wp-connect' ),
+					'' => __( 'All', 'smaily-connect' ),
 				) + wp_list_pluck( $product_categories, 'name', 'slug' ),
-				'help'        => __( 'Show products from specific category.', 'smaily-wp-connect' ),
+				'help'        => __( 'Show products from specific category.', 'smaily-connect' ),
 				'class'       => 'smaily-rss-options',
 				'id'          => 'smaily-rss-category',
 			)
@@ -416,19 +416,19 @@ class Settings {
 
 		add_settings_field(
 			Options::RSS_SORT_BY_OPTION,
-			__( 'Sort by', 'smaily-wp-connect' ),
+			__( 'Sort by', 'smaily-connect' ),
 			array( $this->renderer, 'render_select_field' ),
 			$page,
 			$rss_section,
 			array(
 				'option_name' => Options::RSS_SORT_BY_OPTION,
 				'options'     => array(
-					'modified' => __( 'Modified At', 'smaily-wp-connect' ),
-					'date'     => __( 'Created At', 'smaily-wp-connect' ),
-					'id'       => __( 'ID', 'smaily-wp-connect' ),
-					'name'     => __( 'Name', 'smaily-wp-connect' ),
-					'rand'     => __( 'Random', 'smaily-wp-connect' ),
-					'type'     => __( 'Type', 'smaily-wp-connect' ),
+					'modified' => __( 'Modified At', 'smaily-connect' ),
+					'date'     => __( 'Created At', 'smaily-connect' ),
+					'id'       => __( 'ID', 'smaily-connect' ),
+					'name'     => __( 'Name', 'smaily-connect' ),
+					'rand'     => __( 'Random', 'smaily-connect' ),
+					'type'     => __( 'Type', 'smaily-connect' ),
 				),
 				'class'       => 'smaily-rss-options',
 				'id'          => 'smaily-rss-sort-field',
@@ -437,15 +437,15 @@ class Settings {
 
 		add_settings_field(
 			Options::RSS_ORDER_BY_OPTION,
-			__( 'Order by', 'smaily-wp-connect' ),
+			__( 'Order by', 'smaily-connect' ),
 			array( $this->renderer, 'render_select_field' ),
 			$page,
 			$rss_section,
 			array(
 				'option_name' => Options::RSS_ORDER_BY_OPTION,
 				'options'     => array(
-					'ASC'  => __( 'Ascending', 'smaily-wp-connect' ),
-					'DESC' => __( 'Descending', 'smaily-wp-connect' ),
+					'ASC'  => __( 'Ascending', 'smaily-connect' ),
+					'DESC' => __( 'Descending', 'smaily-connect' ),
 				),
 				'class'       => 'smaily-rss-options',
 				'id'          => 'smaily-rss-sort-order',
@@ -454,7 +454,7 @@ class Settings {
 
 		add_settings_field(
 			Options::RSS_URL_OPTION,
-			__( 'Product RSS feed', 'smaily-wp-connect' ),
+			__( 'Product RSS feed', 'smaily-connect' ),
 			array( $this->renderer, 'render_rss_url' ),
 			$page,
 			$rss_section

--- a/admin/smaily-admin-settings.class.php
+++ b/admin/smaily-admin-settings.class.php
@@ -41,7 +41,7 @@ class Settings {
 	 *
 	 */
 	public function register_connection_tab_settings( $option_group, $page ) {
-		$section = 'smaily_wp_connect_connection_section';
+		$section = 'smaily_connect_connection_section';
 
 		register_setting(
 			$option_group,
@@ -79,7 +79,7 @@ class Settings {
 	 */
 	public function register_tutorial_tab_settings( $option_group, $page ) {
 		add_settings_section(
-			'smaily_wp_connect_subscriber_collection_section',
+			'smaily_connect_subscriber_collection_section',
 			__( 'Setting up subscriber collection', 'smaily-connect' ),
 			array( $this->renderer, 'render_tutorial_subscriber_collection_section' ),
 			$page
@@ -87,7 +87,7 @@ class Settings {
 
 		if ( Helper::is_woocommerce_active() ) {
 			add_settings_section(
-				'smaily_wp_connect_woocommerce_section',
+				'smaily_connect_woocommerce_section',
 				__( 'WooCommerce Integration', 'smaily-connect' ),
 				array( $this->renderer, 'render_tutorial_woocommerce_section' ),
 				$page
@@ -101,7 +101,7 @@ class Settings {
 	 * @return void
 	 */
 	public function register_subscriber_sync_tab_settings( $option_group, $page ) {
-		$subscriber_sync_section = 'smaily_wp_connect_subscriber_sync_section';
+		$subscriber_sync_section = 'smaily_connect_subscriber_sync_section';
 
 		register_setting(
 			$option_group,
@@ -150,7 +150,7 @@ class Settings {
 			$subscriber_sync_section
 		);
 
-		$checkout_subscription_section = 'smaily_wp_connect_checkout_subscription_section';
+		$checkout_subscription_section = 'smaily_connect_checkout_subscription_section';
 		register_setting(
 			$option_group,
 			Options::CHECKOUT_SUBSCRIPTION_ENABLED_OPTION,
@@ -230,7 +230,7 @@ class Settings {
 	 * @return void
 	 */
 	public function register_abandoned_cart_tab_settings( $option_group, $page ) {
-		$abandoned_cart_section = 'smaily_wp_connect_abandoned_cart_section';
+		$abandoned_cart_section = 'smaily_connect_abandoned_cart_section';
 
 		register_setting(
 			$option_group,
@@ -308,7 +308,7 @@ class Settings {
 	 * @return void
 	 */
 	public function register_rss_tab_settings( $option_group, $page ) {
-		$rss_section = 'smaily_wp_connect_rss_section';
+		$rss_section = 'smaily_connect_rss_section';
 
 		register_setting(
 			$option_group,

--- a/admin/smaily-admin.class.php
+++ b/admin/smaily-admin.class.php
@@ -79,7 +79,7 @@ class Admin {
 		add_action( 'pre_update_option_' . Options::API_CREDENTIALS_OPTION, array( $this, 'validate_api_credentials_after_save' ), 10, 3 );
 		add_action( 'widgets_init', array( $this, 'smaily_subscription_widget_init' ) );
 		add_action( 'wp_ajax_smaily_admin_save', array( $this, 'smaily_admin_save' ) );
-		add_filter( 'plugin_action_links_' . plugin_basename( SMAILY_WP_CONNECT_PLUGIN_FILE ), array( $this, 'settings_link' ) );
+		add_filter( 'plugin_action_links_' . plugin_basename( SMAILY_CONNECT_PLUGIN_FILE ), array( $this, 'settings_link' ) );
 	}
 
 	/**
@@ -94,7 +94,7 @@ class Admin {
 			'manage_options',
 			$this->plugin_name,
 			array( $this, 'render_admin_page' ),
-			'data:image/svg+xml;base64,' . base64_encode( file_get_contents( SMAILY_WP_CONNECT_PLUGIN_PATH . '/gfx/icon.svg' ) )
+			'data:image/svg+xml;base64,' . base64_encode( file_get_contents( SMAILY_CONNECT_PLUGIN_PATH . '/gfx/icon.svg' ) )
 		);
 	}
 
@@ -107,7 +107,7 @@ class Admin {
 			return wp_die( 'Insufficient permissions' );
 		}
 
-		include_once SMAILY_WP_CONNECT_PLUGIN_PATH . '/admin/partials/smaily-admin-page.php';
+		include_once SMAILY_CONNECT_PLUGIN_PATH . '/admin/partials/smaily-admin-page.php';
 	}
 
 	/**
@@ -300,10 +300,10 @@ class Admin {
 	 *
 	 */
 	public function enqueue_styles() {
-		wp_register_style( $this->plugin_name, SMAILY_WP_CONNECT_PLUGIN_URL . '/admin/css/smaily-admin.css', array(), $this->version, 'all' );
-		wp_register_style( $this->plugin_name . '-widget', SMAILY_WP_CONNECT_PLUGIN_URL . '/admin/css/smaily-widget-admin.css', array(), $this->version, 'all' );
+		wp_register_style( $this->plugin_name, SMAILY_CONNECT_PLUGIN_URL . '/admin/css/smaily-admin.css', array(), $this->version, 'all' );
+		wp_register_style( $this->plugin_name . '-widget', SMAILY_CONNECT_PLUGIN_URL . '/admin/css/smaily-widget-admin.css', array(), $this->version, 'all' );
 
-		wp_enqueue_style( $this->plugin_name . '-fonts', SMAILY_WP_CONNECT_PLUGIN_URL . '/admin/css/fonts.css', array(), null );
+		wp_enqueue_style( $this->plugin_name . '-fonts', SMAILY_CONNECT_PLUGIN_URL . '/admin/css/fonts.css', array(), null );
 		wp_enqueue_style( $this->plugin_name );
 		wp_enqueue_style( $this->plugin_name . '-widget' );
 	}
@@ -313,9 +313,9 @@ class Admin {
 	 *
 	 */
 	public function enqueue_scripts() {
-		wp_register_script( $this->plugin_name . '-jscolor', SMAILY_WP_CONNECT_PLUGIN_URL . '/admin/js/jscolor.min.js', array(), $this->version, true );
-		wp_register_script( $this->plugin_name, SMAILY_WP_CONNECT_PLUGIN_URL . '/admin/js/smaily-admin.js', array( 'jquery', 'jquery-ui-tabs' ), $this->version, true );
-		wp_register_script( $this->plugin_name . '-widget', SMAILY_WP_CONNECT_PLUGIN_URL . '/admin/js/admin-widget.js', array( 'jquery', $this->plugin_name . '-jscolor' ), $this->version, true );
+		wp_register_script( $this->plugin_name . '-jscolor', SMAILY_CONNECT_PLUGIN_URL . '/admin/js/jscolor.min.js', array(), $this->version, true );
+		wp_register_script( $this->plugin_name, SMAILY_CONNECT_PLUGIN_URL . '/admin/js/smaily-admin.js', array( 'jquery', 'jquery-ui-tabs' ), $this->version, true );
+		wp_register_script( $this->plugin_name . '-widget', SMAILY_CONNECT_PLUGIN_URL . '/admin/js/admin-widget.js', array( 'jquery', $this->plugin_name . '-jscolor' ), $this->version, true );
 
 		wp_enqueue_script( $this->plugin_name . '-jscolor' );
 		wp_enqueue_script( $this->plugin_name );

--- a/admin/smaily-admin.class.php
+++ b/admin/smaily-admin.class.php
@@ -145,7 +145,7 @@ class Admin {
 		$credentials_valid = $this->validate_api_credentials( $new_value['subdomain'], $new_value['username'], $new_value['password'] );
 		if ( $credentials_valid[0] === true ) {
 			add_settings_error(
-				'smaily_wp_connect_messages',
+				'smaily_connect_messages',
 				'credentials_validated',
 				__( 'API credentials validated successfully!', 'smaily-connect' ),
 				'success'
@@ -160,7 +160,7 @@ class Admin {
 			switch ( $credentials_valid[1] ) {
 				case 404:
 					add_settings_error(
-						'smaily_wp_connect_messages',
+						'smaily_connect_messages',
 						'invalid_api_credentials',
 						__( 'Check subdomain. API credentials validation failed.', 'smaily-connect' ),
 						'error'
@@ -168,7 +168,7 @@ class Admin {
 					break;
 				default:
 					add_settings_error(
-						'smaily_wp_connect_messages',
+						'smaily_connect_messages',
 						'invalid_api_credentials',
 						__( 'API credentials validation failed. Please check your details.', 'smaily-connect' ),
 						'error'
@@ -221,8 +221,8 @@ class Admin {
 						''
 					),
 					'register_settings'  => array( $this->settings, 'register_connection_tab_settings' ),
-					'option_group'       => 'smaily_wp_connect_connection',
-					'page'               => 'smaily_wp_connect_tab_connection',
+					'option_group'       => 'smaily_connect_connection',
+					'page'               => 'smaily_connect_tab_connection',
 				),
 			);
 
@@ -237,8 +237,8 @@ class Admin {
 						''
 					),
 					'register_settings' => array( $this->settings, 'register_tutorial_tab_settings' ),
-					'option_group'      => 'smaily_wp_connect_tutorial',
-					'page'              => 'smaily_wp_connect_tab_tutorial',
+					'option_group'      => 'smaily_connect_tutorial',
+					'page'              => 'smaily_connect_tab_tutorial',
 				);
 			}
 
@@ -254,8 +254,8 @@ class Admin {
 						''
 					),
 					'register_settings'  => array( $this->settings, 'register_subscriber_sync_tab_settings' ),
-					'option_group'       => 'smaily_wp_connect_subscriber_sync',
-					'page'               => 'smaily_wp_connect_tab_subscriber_sync',
+					'option_group'       => 'smaily_connect_subscriber_sync',
+					'page'               => 'smaily_connect_tab_subscriber_sync',
 				);
 
 				$tabs['abandoned_cart'] = array(
@@ -269,8 +269,8 @@ class Admin {
 						''
 					),
 					'register_settings'  => array( $this->settings, 'register_abandoned_cart_tab_settings' ),
-					'option_group'       => 'smaily_wp_connect_abandoned_cart',
-					'page'               => 'smaily_wp_connect_tab_abandoned_cart',
+					'option_group'       => 'smaily_connect_abandoned_cart',
+					'page'               => 'smaily_connect_tab_abandoned_cart',
 				);
 
 				$tabs['rss'] = array(
@@ -284,8 +284,8 @@ class Admin {
 						''
 					),
 					'register_settings'  => array( $this->settings, 'register_rss_tab_settings' ),
-					'option_group'       => 'smaily_wp_connect_rss',
-					'page'               => 'smaily_wp_connect_tab_rss',
+					'option_group'       => 'smaily_connect_rss',
+					'page'               => 'smaily_connect_tab_rss',
 				);
 			}
 

--- a/admin/smaily-admin.class.php
+++ b/admin/smaily-admin.class.php
@@ -89,7 +89,7 @@ class Admin {
 	 */
 	public function settings_page() {
 		add_menu_page(
-			__( 'Smaily Settings', 'smaily-wp-connect' ),
+			__( 'Smaily Settings', 'smaily-connect' ),
 			'Smaily',
 			'manage_options',
 			$this->plugin_name,
@@ -147,7 +147,7 @@ class Admin {
 			add_settings_error(
 				'smaily_wp_connect_messages',
 				'credentials_validated',
-				__( 'API credentials validated successfully!', 'smaily-wp-connect' ),
+				__( 'API credentials validated successfully!', 'smaily-connect' ),
 				'success'
 			);
 
@@ -162,7 +162,7 @@ class Admin {
 					add_settings_error(
 						'smaily_wp_connect_messages',
 						'invalid_api_credentials',
-						__( 'Check subdomain. API credentials validation failed.', 'smaily-wp-connect' ),
+						__( 'Check subdomain. API credentials validation failed.', 'smaily-connect' ),
 						'error'
 					);
 					break;
@@ -170,7 +170,7 @@ class Admin {
 					add_settings_error(
 						'smaily_wp_connect_messages',
 						'invalid_api_credentials',
-						__( 'API credentials validation failed. Please check your details.', 'smaily-wp-connect' ),
+						__( 'API credentials validation failed. Please check your details.', 'smaily-connect' ),
 						'error'
 					);
 					break;
@@ -211,8 +211,8 @@ class Admin {
 		if ( ! isset( $this->tabs ) ) {
 			$tabs = array(
 				'connection' => array(
-					'title'              => __( 'Connection', 'smaily-wp-connect' ),
-					'submit_button_text' => $this->options->has_credentials() ? __( 'Disconnect', 'smaily-wp-connect' ) : __( 'Make a connection', 'smaily-wp-connect' ),
+					'title'              => __( 'Connection', 'smaily-connect' ),
+					'submit_button_text' => $this->options->has_credentials() ? __( 'Disconnect', 'smaily-connect' ) : __( 'Make a connection', 'smaily-connect' ),
 					'url'                => add_query_arg(
 						array(
 							'page' => $this->plugin_name,
@@ -228,7 +228,7 @@ class Admin {
 
 			if ( $this->options->has_credentials() ) {
 				$tabs['tutorial'] = array(
-					'title'             => __( 'Getting started', 'smaily-wp-connect' ),
+					'title'             => __( 'Getting started', 'smaily-connect' ),
 					'url'               => add_query_arg(
 						array(
 							'page' => $this->plugin_name,
@@ -244,8 +244,8 @@ class Admin {
 
 			if ( Helper::is_woocommerce_active() && $this->options->has_credentials() ) {
 				$tabs['subscriber_sync'] = array(
-					'title'              => __( 'Subscriber Synchronization', 'smaily-wp-connect' ),
-					'submit_button_text' => __( 'Save', 'smaily-wp-connect' ),
+					'title'              => __( 'Subscriber Synchronization', 'smaily-connect' ),
+					'submit_button_text' => __( 'Save', 'smaily-connect' ),
 					'url'                => add_query_arg(
 						array(
 							'page' => $this->plugin_name,
@@ -259,8 +259,8 @@ class Admin {
 				);
 
 				$tabs['abandoned_cart'] = array(
-					'title'              => __( 'Abandoned Cart', 'smaily-wp-connect' ),
-					'submit_button_text' => __( 'Save', 'smaily-wp-connect' ),
+					'title'              => __( 'Abandoned Cart', 'smaily-connect' ),
+					'submit_button_text' => __( 'Save', 'smaily-connect' ),
 					'url'                => add_query_arg(
 						array(
 							'page' => $this->plugin_name,
@@ -274,8 +274,8 @@ class Admin {
 				);
 
 				$tabs['rss'] = array(
-					'title'              => __( 'RSS', 'smaily-wp-connect' ),
-					'submit_button_text' => __( 'Save', 'smaily-wp-connect' ),
+					'title'              => __( 'RSS', 'smaily-connect' ),
+					'submit_button_text' => __( 'Save', 'smaily-connect' ),
 					'url'                => add_query_arg(
 						array(
 							'page' => $this->plugin_name,
@@ -343,7 +343,7 @@ class Admin {
 	 */
 	public function settings_link( $links ) {
 		// receive all current links and add custom link to the list.
-		$settings_link = '<a href="admin.php?page=' . esc_attr( $this->plugin_name ) . '">' . esc_html__( 'Settings', 'smaily-wp-connect' ) . '</a>';
+		$settings_link = '<a href="admin.php?page=' . esc_attr( $this->plugin_name ) . '">' . esc_html__( 'Settings', 'smaily-connect' ) . '</a>';
 		// Settings before disable.
 		array_unshift( $links, $settings_link );
 		return $links;

--- a/admin/smaily-admin.class.php
+++ b/admin/smaily-admin.class.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Smaily_WP_Connect;
+namespace Smaily_Connect;
 
-use Smaily_WP_Connect\Admin\Settings;
-use Smaily_WP_Connect\Includes\Cypher;
-use Smaily_WP_Connect\Includes\Helper;
-use Smaily_WP_Connect\Includes\Options;
-use Smaily_WP_Connect\Includes\Smaily_Client;
-use Smaily_WP_Connect\Includes\Widget;
-use Smaily_WP_Connect\Integrations\WooCommerce\Rss;
+use Smaily_Connect\Admin\Settings;
+use Smaily_Connect\Includes\Cypher;
+use Smaily_Connect\Includes\Helper;
+use Smaily_Connect\Includes\Options;
+use Smaily_Connect\Includes\Smaily_Client;
+use Smaily_Connect\Includes\Widget;
+use Smaily_Connect\Integrations\WooCommerce\Rss;
 
 class Admin {
 	/**

--- a/blocks/checkout-optin/package-lock.json
+++ b/blocks/checkout-optin/package-lock.json
@@ -13,7 +13,7 @@
 				"@woocommerce/dependency-extraction-webpack-plugin": "^3.1.0",
 				"@wordpress/prettier-config": "^2.18.2",
 				"@wordpress/scripts": "^27",
-				"eslint-plugin-prettier": "^5.2.5",
+				"eslint-plugin-prettier": "^5.2.6",
 				"prettier": "npm:wp-prettier@^3.0.3"
 			}
 		},
@@ -3017,16 +3017,16 @@
 			}
 		},
 		"node_modules/@pkgr/core": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.0.tgz",
-			"integrity": "sha512-vsJDAkYR6qCPu+ioGScGiMYR7LvZYIXh/dlQeviqoTWNCVfKTLYD/LkNWH4Mxsv2a5vpIRc77FN5DnmK1eBggQ==",
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.4.tgz",
+			"integrity": "sha512-ROFF39F6ZrnzSUEmQQZUar0Jt4xVoP9WnDRdWwF4NNcXs3xBTLgBUDoOwW141y1jP+S8nahIbdxbFC7IShw9Iw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
 			},
 			"funding": {
-				"url": "https://opencollective.com/unts"
+				"url": "https://opencollective.com/pkgr"
 			}
 		},
 		"node_modules/@playwright/test": {
@@ -8919,14 +8919,14 @@
 			}
 		},
 		"node_modules/eslint-plugin-prettier": {
-			"version": "5.2.5",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.5.tgz",
-			"integrity": "sha512-IKKP8R87pJyMl7WWamLgPkloB16dagPIdd2FjBDbyRYPKo93wS/NbCOPh6gH+ieNLC+XZrhJt/kWj0PS/DFdmg==",
+			"version": "5.2.6",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.6.tgz",
+			"integrity": "sha512-mUcf7QG2Tjk7H055Jk0lGBjbgDnfrvqjhXh9t2xLMSCjZVcw9Rb1V6sVNXO0th3jgeO7zllWPTNRil3JW94TnQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"prettier-linter-helpers": "^1.0.0",
-				"synckit": "^0.10.2"
+				"synckit": "^0.11.0"
 			},
 			"engines": {
 				"node": "^14.18.0 || >=16.0.0"
@@ -18393,20 +18393,20 @@
 			"license": "MIT"
 		},
 		"node_modules/synckit": {
-			"version": "0.10.3",
-			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.10.3.tgz",
-			"integrity": "sha512-R1urvuyiTaWfeCggqEvpDJwAlDVdsT9NM+IP//Tk2x7qHCkSvBk/fwFgw/TLAHzZlrAnnazMcRw0ZD8HlYFTEQ==",
+			"version": "0.11.4",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.4.tgz",
+			"integrity": "sha512-Q/XQKRaJiLiFIBNN+mndW7S/RHxvwzuZS6ZwmRzUBqJBv/5QIKCEwkBC8GBf8EQJKYnaFs0wOZbKTXBPj8L9oQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@pkgr/core": "^0.2.0",
+				"@pkgr/core": "^0.2.3",
 				"tslib": "^2.8.1"
 			},
 			"engines": {
 				"node": "^14.18.0 || >=16.0.0"
 			},
 			"funding": {
-				"url": "https://opencollective.com/unts"
+				"url": "https://opencollective.com/synckit"
 			}
 		},
 		"node_modules/table": {

--- a/blocks/checkout-optin/package.json
+++ b/blocks/checkout-optin/package.json
@@ -17,7 +17,7 @@
 		"@woocommerce/dependency-extraction-webpack-plugin": "^3.1.0",
 		"@wordpress/prettier-config": "^2.18.2",
 		"@wordpress/scripts": "^27",
-		"eslint-plugin-prettier": "^5.2.5",
+		"eslint-plugin-prettier": "^5.2.6",
 		"prettier": "npm:wp-prettier@^3.0.3"
 	},
 	"prettier": "@wordpress/prettier-config"

--- a/blocks/checkout-optin/smaily-extend-store-endpoint.class.php
+++ b/blocks/checkout-optin/smaily-extend-store-endpoint.class.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Smaily_WP_Connect\Blocks\Checkout_Optin;
+namespace Smaily_Connect\Blocks\Checkout_Optin;
 
 use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
 use Automattic\WooCommerce\StoreApi\Schemas\V1\CheckoutSchema;

--- a/blocks/checkout-optin/smaily-extend-store-endpoint.class.php
+++ b/blocks/checkout-optin/smaily-extend-store-endpoint.class.php
@@ -53,7 +53,7 @@ class Extend_Store_Endpoint {
 	public static function extend_checkout_schema() {
 		return array(
 			'user_newsletter' => array(
-				'description' => __( 'User newsletter subscription', 'smaily-wp-connect' ),
+				'description' => __( 'User newsletter subscription', 'smaily-connect' ),
 				'type'        => 'boolean',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => false,

--- a/blocks/checkout-optin/smaily-integration.class.php
+++ b/blocks/checkout-optin/smaily-integration.class.php
@@ -56,7 +56,7 @@ class Integration implements IntegrationInterface {
 
 		$data = array(
 			'smailyCheckoutOptinActive' => $enabled,
-			'optInDefaultText'          => __( 'Subscribe to newsletter', 'smaily-wp-connect' ),
+			'optInDefaultText'          => __( 'Subscribe to newsletter', 'smaily-connect' ),
 		);
 
 		return $data;
@@ -83,7 +83,7 @@ class Integration implements IntegrationInterface {
 
 		wp_set_script_translations(
 			'smaily-checkout-optin-block-editor', // script handle
-			'smaily-wp-connect', // text domain
+			'smaily-connect', // text domain
 			__DIR__ . '/languages'
 		);
 	}
@@ -108,7 +108,7 @@ class Integration implements IntegrationInterface {
 		);
 		wp_set_script_translations(
 			'smaily-checkout-optin-block-frontend', // script handle
-			'smaily-wp-connect', // text domain
+			'smaily-connect', // text domain
 			__DIR__ . '/languages'
 		);
 	}

--- a/blocks/checkout-optin/smaily-integration.class.php
+++ b/blocks/checkout-optin/smaily-integration.class.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Smaily_WP_Connect\Blocks\Checkout_Optin;
+namespace Smaily_Connect\Blocks\Checkout_Optin;
 
-use Smaily_WP_Connect\Includes\Options;
+use Smaily_Connect\Includes\Options;
 use Automattic\WooCommerce\Blocks\Integrations\IntegrationInterface;
 
 define( 'SMAILY_CHECKOUT_OPTIN_VERSION', '1.0.0' );

--- a/blocks/checkout-optin/src/block.json
+++ b/blocks/checkout-optin/src/block.json
@@ -28,7 +28,7 @@
 			"default": ""
 		}
 	},
-	"textdomain": "smaily-wp-connect",
+	"textdomain": "smaily-connect",
 	"editorScript": "file:./smaily-checkout-optin-block.js",
 	"editorStyle": "file:./style-smaily-checkout-optin-block.css"
 }

--- a/blocks/checkout-optin/src/index.js
+++ b/blocks/checkout-optin/src/index.js
@@ -25,14 +25,14 @@ const smailyIcon = (
 
 registerBlockType( metadata.name, {
 	icon: smailyIcon,
-	title: __( 'Smaily Checkout Opt-In', 'smaily-wp-connect' ),
+	title: __( 'Smaily Checkout Opt-In', 'smaily-connect' ),
 	description: __(
 		'Adds a newsletter subscription checkbox to the checkout.',
-		'smaily-wp-connect'
+		'smaily-connect'
 	),
 	keywords: [
-		__( 'checkout', 'smaily-wp-connect' ),
-		__( 'newsletter', 'smaily-wp-connect' ),
+		__( 'checkout', 'smaily-connect' ),
+		__( 'newsletter', 'smaily-connect' ),
 		'smaily',
 	],
 	edit: Edit,

--- a/blocks/newsletter-signup/smaily-integration.class.php
+++ b/blocks/newsletter-signup/smaily-integration.class.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Smaily_WP_Connect\Blocks\Newsletter_Signup;
+namespace Smaily_Connect\Blocks\Newsletter_Signup;
 
-use Smaily_WP_Connect\Includes\Helper;
+use Smaily_Connect\Includes\Helper;
 
 class Integration {
 	/**

--- a/blocks/newsletter-signup/src/block.json
+++ b/blocks/newsletter-signup/src/block.json
@@ -91,7 +91,7 @@
 		},
 		"html": false
 	},
-	"textdomain": "smaily-wp-connect",
+	"textdomain": "smaily-connect",
 	"editorScript": "file:./index.js",
 	"style": "file:./style-index.css"
 }

--- a/blocks/newsletter-signup/src/edit.js
+++ b/blocks/newsletter-signup/src/edit.js
@@ -106,17 +106,17 @@ export default function Edit({ attributes, setAttributes }) {
 				isDismissible={false}
 				actions={[
 					{
-						label: __('Go to plugin settings', 'smaily-wp-connect'),
+						label: __('Go to plugin settings', 'smaily-connect'),
 						onClick: handleRedirect,
 						variant: 'primary',
 					},
 				]}
 			>
-				<h3>{__('Plugin setup is not complete!', 'smaily-wp-connect')}</h3>
+				<h3>{__('Plugin setup is not complete!', 'smaily-connect')}</h3>
 				<p>
 					{__(
 						'Please connect your Smaily account before adding a form!',
-						'smaily-wp-connect'
+						'smaily-connect'
 					)}
 				</p>
 			</Notice>
@@ -169,9 +169,9 @@ export default function Edit({ attributes, setAttributes }) {
 				</div>
 			</div>
 			<InspectorControls>
-				<PanelBody title={__('Visible fields', 'smaily-wp-connect')}>
+				<PanelBody title={__('Visible fields', 'smaily-connect')}>
 					<ToggleControl
-						label={__('Display name field', 'smaily-wp-connect')}
+						label={__('Display name field', 'smaily-connect')}
 						checked={showNameField}
 						onChange={() =>
 							setAttributes({
@@ -182,7 +182,7 @@ export default function Edit({ attributes, setAttributes }) {
 					/>
 					{showNameField && (
 						<TextControl
-							label={__('Name field label', 'smaily-wp-connect')}
+							label={__('Name field label', 'smaily-connect')}
 							value={nameInputLabel}
 							name="nameInputLabel"
 							onChange={(val) =>
@@ -191,7 +191,7 @@ export default function Edit({ attributes, setAttributes }) {
 						/>
 					)}
 					<TextControl
-						label={__('Email field label', 'smaily-wp-connect')}
+						label={__('Email field label', 'smaily-connect')}
 						value={emailInputLabel}
 						name="emailInputLabel"
 						onChange={(val) =>
@@ -199,7 +199,7 @@ export default function Edit({ attributes, setAttributes }) {
 						}
 					/>
 					<TextControl
-						label={__('Subscribe button label', 'smaily-wp-connect')}
+						label={__('Subscribe button label', 'smaily-connect')}
 						value={subscribeButtonLabel}
 						name="subscribeButtonLabel"
 						onChange={(val) =>
@@ -207,7 +207,7 @@ export default function Edit({ attributes, setAttributes }) {
 						}
 					/>
 					<ToggleControl
-						label={__('Full width subscribe button', 'smaily-wp-connect')}
+						label={__('Full width subscribe button', 'smaily-connect')}
 						checked={subscribeButtonWidth === '100%'}
 						onChange={(checked) =>
 							setAttributes({
@@ -219,7 +219,7 @@ export default function Edit({ attributes, setAttributes }) {
 						name="show_name"
 					/>
 					<RangeControl
-						label={__('Button border radius', 'smaily-wp-connect')}
+						label={__('Button border radius', 'smaily-connect')}
 						value={attributes.subscribeButtonBorderRadius}
 						onChange={(value) => {
 							setAttributes({
@@ -229,7 +229,7 @@ export default function Edit({ attributes, setAttributes }) {
 						min={0}
 					/>
 					<TextControl
-						label={__('Success message', 'smaily-wp-connect')}
+						label={__('Success message', 'smaily-connect')}
 						value={successMessage}
 						name="successMessage"
 						onChange={(val) =>
@@ -237,32 +237,32 @@ export default function Edit({ attributes, setAttributes }) {
 						}
 					/>
 					<TextControl
-						label={__('Error message', 'smaily-wp-connect')}
+						label={__('Error message', 'smaily-connect')}
 						value={errorMessage}
 						name="errorMessage"
 						onChange={(val) => setAttributes({ errorMessage: val })}
 					/>
 				</PanelBody>
 				<PanelBody
-					title={__('Hidden fields', 'smaily-wp-connect')}
+					title={__('Hidden fields', 'smaily-connect')}
 					initialOpen={false}
 				>
 					<TextControl
-						label={__('Success URL', 'smaily-wp-connect')}
+						label={__('Success URL', 'smaily-connect')}
 						value={successURL}
 						name="successURL"
 						onChange={(val) => setAttributes({ successURL: val })}
-						help={__('Defaults to current page URL.', 'smaily-wp-connect')}
+						help={__('Defaults to current page URL.', 'smaily-connect')}
 					/>
 					<TextControl
-						label={__('Failure URL', 'smaily-wp-connect')}
+						label={__('Failure URL', 'smaily-connect')}
 						value={errorURL}
 						name="failure_url"
 						onChange={(val) => setAttributes({ errorURL: val })}
-						help={__('Defaults to current page URL.', 'smaily-wp-connect')}
+						help={__('Defaults to current page URL.', 'smaily-connect')}
 					/>
 					<SelectControl
-						label={__('Autoresponder', 'smaily-wp-connect')}
+						label={__('Autoresponder', 'smaily-connect')}
 						name="autoresponderId"
 						value={autoresponderId}
 						onChange={(val) =>
@@ -270,7 +270,7 @@ export default function Edit({ attributes, setAttributes }) {
 						}
 						options={[
 							{
-								label: __('No autoresponder', 'smaily-wp-connect'),
+								label: __('No autoresponder', 'smaily-connect'),
 								value: '',
 							},
 							...autoresponders,

--- a/blocks/newsletter-signup/src/index.js
+++ b/blocks/newsletter-signup/src/index.js
@@ -27,10 +27,10 @@ const smailyIcon = (
 registerBlockType(metadata.name, {
 	edit: Edit,
 	icon: smailyIcon,
-	title: __('Smaily Opt-In Form', 'smaily-wp-connect'),
+	title: __('Smaily Opt-In Form', 'smaily-connect'),
 	description: __(
 		'Opt-in subscribers directly to Smaily for seamless email marketing.',
-		'smaily-wp-connect'
+		'smaily-connect'
 	),
-	keywords: [__('email', 'smaily-wp-connect'), __('newsletter', 'smaily-wp-connect'), 'smaily'],
+	keywords: [__('email', 'smaily-connect'), __('newsletter', 'smaily-connect'), 'smaily'],
 });

--- a/compose.yaml
+++ b/compose.yaml
@@ -25,7 +25,7 @@ services:
         # define( 'ALTERNATE_WP_CRON' , true );
     volumes:
     - wordpress:/var/www/html
-    - ./:/var/www/html/wp-content/plugins/smaily-wp-connect
+    - ./:/var/www/html/wp-content/plugins/smaily-connect
 
   db:
     image: mysql:5.7

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "format": "phpcbf .",
         "build:newsletter-signup": "npm --prefix blocks/newsletter-signup/ ci blocks/newsletter-signup/ && npm run build --prefix blocks/newsletter-signup/",
         "build:checkout-optin": "npm --prefix blocks/checkout-optin/ ci blocks/checkout-optin/ && npm run build --prefix blocks/checkout-optin/",
-        "extract-text-domain": "wp i18n make-pot . languages/smaily-wp-connect.pot && msginit -i languages/smaily-wp-connect.pot -o languages/smaily-wp-connect-en.po -l en --no-translator",
-        "compile-translations": "rm -f languages/smaily-wp-connect-en.po && wp i18n update-po languages/smaily-wp-connect.pot languages/ && wp i18n make-mo languages/ && wp i18n make-json languages/ --no-purge",
-        "package": "cat .zipignore | xargs zip -r smaily-wp-connect.zip . -x"
+        "extract-text-domain": "wp i18n make-pot . languages/smaily-connect.pot && msginit -i languages/smaily-connect.pot -o languages/smaily-connect-en.po -l en --no-translator",
+        "compile-translations": "rm -f languages/smaily-connect-en.po && wp i18n update-po languages/smaily-connect.pot languages/ && wp i18n make-mo languages/ && wp i18n make-json languages/ --no-purge",
+        "package": "cat .zipignore | xargs zip -r smaily-connect.zip . -x"
     }
 }

--- a/includes/smaily-api.class.php
+++ b/includes/smaily-api.class.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Smaily_WP_Connect\Includes;
+namespace Smaily_Connect\Includes;
 
-use Smaily_WP_Connect\Admin;
-use Smaily_WP_Connect\Includes\Options;
+use Smaily_Connect\Admin;
+use Smaily_Connect\Includes\Options;
 
 class API {
 	/**

--- a/includes/smaily-blocks.class.php
+++ b/includes/smaily-blocks.class.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Smaily_WP_Connect\Includes;
+namespace Smaily_Connect\Includes;
 
-use Smaily_WP_Connect\Blocks\Checkout_Optin\Extend_Store_Endpoint;
-use Smaily_WP_Connect\Blocks\Checkout_Optin\Integration;
+use Smaily_Connect\Blocks\Checkout_Optin\Extend_Store_Endpoint;
+use Smaily_Connect\Blocks\Checkout_Optin\Integration;
 
 class Blocks {
 	/**
@@ -72,7 +72,7 @@ class Blocks {
 		register_block_type(
 			SMAILY_CONNECT_PLUGIN_PATH . '/blocks/newsletter-signup/build',
 			array(
-				'render_callback' => array( 'Smaily_WP_Connect\Blocks\Newsletter_Signup\Integration', 'render' ),
+				'render_callback' => array( 'Smaily_Connect\Blocks\Newsletter_Signup\Integration', 'render' ),
 			)
 		);
 		wp_set_script_translations(

--- a/includes/smaily-blocks.class.php
+++ b/includes/smaily-blocks.class.php
@@ -70,7 +70,7 @@ class Blocks {
 		wp_enqueue_style( 'wp-components' );
 
 		register_block_type(
-			SMAILY_WP_CONNECT_PLUGIN_PATH . '/blocks/newsletter-signup/build',
+			SMAILY_CONNECT_PLUGIN_PATH . '/blocks/newsletter-signup/build',
 			array(
 				'render_callback' => array( 'Smaily_WP_Connect\Blocks\Newsletter_Signup\Integration', 'render' ),
 			)
@@ -78,7 +78,7 @@ class Blocks {
 		wp_set_script_translations(
 			'smaily-newsletter-block-editor-script',
 			'smaily-connect',
-			SMAILY_WP_CONNECT_PLUGIN_PATH . 'languages'
+			SMAILY_CONNECT_PLUGIN_PATH . 'languages'
 		);
 	}
 
@@ -88,11 +88,11 @@ class Blocks {
 	 * @return void
 	 */
 	public function register_checkout_optin_block() {
-		register_block_type( SMAILY_WP_CONNECT_PLUGIN_PATH . '/blocks/checkout-optin/build' );
+		register_block_type( SMAILY_CONNECT_PLUGIN_PATH . '/blocks/checkout-optin/build' );
 		wp_set_script_translations(
 			'smaily-checkout-optin-editor-script',
 			'smaily-connect',
-			SMAILY_WP_CONNECT_PLUGIN_PATH . 'languages'
+			SMAILY_CONNECT_PLUGIN_PATH . 'languages'
 		);
 	}
 
@@ -114,8 +114,8 @@ class Blocks {
 	 */
 	public function register_checkout_block_for_woocommerce() {
 		// Load after WooCommerce blocks are loaded.
-		require_once SMAILY_WP_CONNECT_PLUGIN_PATH . 'blocks/checkout-optin/smaily-extend-store-endpoint.class.php';
-		require_once SMAILY_WP_CONNECT_PLUGIN_PATH . 'blocks/checkout-optin/smaily-integration.class.php';
+		require_once SMAILY_CONNECT_PLUGIN_PATH . 'blocks/checkout-optin/smaily-extend-store-endpoint.class.php';
+		require_once SMAILY_CONNECT_PLUGIN_PATH . 'blocks/checkout-optin/smaily-integration.class.php';
 
 		Extend_Store_Endpoint::init();
 

--- a/includes/smaily-blocks.class.php
+++ b/includes/smaily-blocks.class.php
@@ -77,7 +77,7 @@ class Blocks {
 		);
 		wp_set_script_translations(
 			'smaily-newsletter-block-editor-script',
-			'smaily-wp-connect',
+			'smaily-connect',
 			SMAILY_WP_CONNECT_PLUGIN_PATH . 'languages'
 		);
 	}
@@ -91,7 +91,7 @@ class Blocks {
 		register_block_type( SMAILY_WP_CONNECT_PLUGIN_PATH . '/blocks/checkout-optin/build' );
 		wp_set_script_translations(
 			'smaily-checkout-optin-editor-script',
-			'smaily-wp-connect',
+			'smaily-connect',
 			SMAILY_WP_CONNECT_PLUGIN_PATH . 'languages'
 		);
 	}

--- a/includes/smaily-client.class.php
+++ b/includes/smaily-client.class.php
@@ -140,7 +140,7 @@ class Smaily_Client {
 	 */
 	private function request( string $endpoint, array $data, $method = 'GET' ) {
 		$response  = array();
-		$useragent = 'smaily-connect/' . SMAILY_WP_CONNECT_PLUGIN_VERSION . ' (WordPress/' . get_bloginfo( 'version' ) . '; +' . get_bloginfo( 'url' ) . ')';
+		$useragent = 'smaily-connect/' . SMAILY_CONNECT_PLUGIN_VERSION . ' (WordPress/' . get_bloginfo( 'version' ) . '; +' . get_bloginfo( 'url' ) . ')';
 		$args      = array(
 			'headers'    => array(
 				'Authorization' => 'Basic ' . base64_encode( $this->_username . ':' . $this->_password ),

--- a/includes/smaily-client.class.php
+++ b/includes/smaily-client.class.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Smaily_WP_Connect\Includes;
+namespace Smaily_Connect\Includes;
 
-use Smaily_WP_Connect\Includes\Options;
+use Smaily_Connect\Includes\Options;
 
 class Smaily_Client {
 	/**

--- a/includes/smaily-client.class.php
+++ b/includes/smaily-client.class.php
@@ -140,7 +140,7 @@ class Smaily_Client {
 	 */
 	private function request( string $endpoint, array $data, $method = 'GET' ) {
 		$response  = array();
-		$useragent = 'smaily-wp-connect/' . SMAILY_WP_CONNECT_PLUGIN_VERSION . ' (WordPress/' . get_bloginfo( 'version' ) . '; +' . get_bloginfo( 'url' ) . ')';
+		$useragent = 'smaily-connect/' . SMAILY_WP_CONNECT_PLUGIN_VERSION . ' (WordPress/' . get_bloginfo( 'version' ) . '; +' . get_bloginfo( 'url' ) . ')';
 		$args      = array(
 			'headers'    => array(
 				'Authorization' => 'Basic ' . base64_encode( $this->_username . ':' . $this->_password ),

--- a/includes/smaily-cypher.class.php
+++ b/includes/smaily-cypher.class.php
@@ -3,7 +3,7 @@
  * Defines the encryption and decryption functionality.
  */
 
-namespace Smaily_WP_Connect\Includes;
+namespace Smaily_Connect\Includes;
 
 class Cypher {
 	/**

--- a/includes/smaily-helper.class.php
+++ b/includes/smaily-helper.class.php
@@ -250,7 +250,7 @@ class Helper {
 	 * @return void
 	 */
 	public static function set_user_language_code( int $user_id ) {
-		update_user_meta( $user_id, 'smaily_wp_connect_user_language', self::get_user_language_code( $user_id ) );
+		update_user_meta( $user_id, 'smaily_connect_user_language', self::get_user_language_code( $user_id ) );
 	}
 
 	/**
@@ -263,7 +263,7 @@ class Helper {
 	 */
 	public static function get_user_language_code( $user_id = null ) {
 		if ( $user_id ) {
-			$lang = get_user_meta( $user_id, 'smaily_wp_connect_user_language', true );
+			$lang = get_user_meta( $user_id, 'smaily_connect_user_language', true );
 			if ( ! empty( $lang ) ) {
 				return $lang;
 			}

--- a/includes/smaily-helper.class.php
+++ b/includes/smaily-helper.class.php
@@ -3,7 +3,7 @@
  * Smaily helper class with static methods
  */
 
-namespace Smaily_WP_Connect\Includes;
+namespace Smaily_Connect\Includes;
 
 class Helper {
 	/**

--- a/includes/smaily-lifecycle.class.php
+++ b/includes/smaily-lifecycle.class.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Smaily_WP_Connect\Includes;
+namespace Smaily_Connect\Includes;
 
-use Smaily_WP_Connect\Integrations\WooCommerce\Cart;
+use Smaily_Connect\Integrations\WooCommerce\Cart;
 
 class Lifecycle {
 	/**

--- a/includes/smaily-lifecycle.class.php
+++ b/includes/smaily-lifecycle.class.php
@@ -246,7 +246,7 @@ class Lifecycle {
 	 */
 	public function set_locale() {
 		load_plugin_textdomain(
-			'smaily-wp-connect',
+			'smaily-connect',
 			false,
 			plugin_basename( SMAILY_WP_CONNECT_PLUGIN_PATH ) . '/languages/'
 		);

--- a/includes/smaily-lifecycle.class.php
+++ b/includes/smaily-lifecycle.class.php
@@ -27,9 +27,9 @@ class Lifecycle {
 	 * @return void
 	 */
 	public function register_hooks() {
-		register_activation_hook( SMAILY_WP_CONNECT_PLUGIN_FILE, array( $this, 'activate' ) );
-		register_deactivation_hook( SMAILY_WP_CONNECT_PLUGIN_FILE, array( $this, 'deactivate' ) );
-		register_uninstall_hook( SMAILY_WP_CONNECT_PLUGIN_FILE, array( __CLASS__, 'uninstall' ) );
+		register_activation_hook( SMAILY_CONNECT_PLUGIN_FILE, array( $this, 'activate' ) );
+		register_deactivation_hook( SMAILY_CONNECT_PLUGIN_FILE, array( $this, 'deactivate' ) );
+		register_uninstall_hook( SMAILY_CONNECT_PLUGIN_FILE, array( __CLASS__, 'uninstall' ) );
 		add_action( 'plugins_loaded', array( $this, 'set_locale' ) );
 		add_action( 'plugins_loaded', array( $this, 'update' ) );
 		add_action( 'upgrader_process_complete', array( $this, 'check_for_update' ), 10, 2 );
@@ -181,7 +181,7 @@ class Lifecycle {
 	 * @param array           $options         Array of bulk item update data.
 	 */
 	public function check_for_update( $upgrader_object, $options ) {
-		$smaily_basename = plugin_basename( SMAILY_WP_CONNECT_PLUGIN_FILE );
+		$smaily_basename = plugin_basename( SMAILY_CONNECT_PLUGIN_FILE );
 
 		$plugin_was_updated = $options['action'] === 'update' && $options['type'] === 'plugin';
 		if ( ! isset( $options['plugins'] ) || ! $plugin_was_updated ) {
@@ -206,7 +206,7 @@ class Lifecycle {
 	 * @access private
 	 */
 	private function run_migrations() {
-		$plugin_version = SMAILY_WP_CONNECT_PLUGIN_VERSION;
+		$plugin_version = SMAILY_CONNECT_PLUGIN_VERSION;
 		$db_version     = get_option( Options::DATABASE_VERSION_OPTION, '0.0.0' );
 
 		if ( $plugin_version === $db_version ) {
@@ -221,7 +221,7 @@ class Lifecycle {
 				continue;
 			}
 
-			$migration_file = SMAILY_WP_CONNECT_PLUGIN_PATH . 'migrations/' . $migration_file;
+			$migration_file = SMAILY_CONNECT_PLUGIN_PATH . 'migrations/' . $migration_file;
 			if ( ! file_exists( $migration_file ) ) {
 				continue;
 			}
@@ -248,7 +248,7 @@ class Lifecycle {
 		load_plugin_textdomain(
 			'smaily-connect',
 			false,
-			plugin_basename( SMAILY_WP_CONNECT_PLUGIN_PATH ) . '/languages/'
+			plugin_basename( SMAILY_CONNECT_PLUGIN_PATH ) . '/languages/'
 		);
 	}
 }

--- a/includes/smaily-lifecycle.class.php
+++ b/includes/smaily-lifecycle.class.php
@@ -46,7 +46,7 @@ class Lifecycle {
 			$this->set_scheduled_actions();
 
 			// Set to flush rewrite rules during init action if not yet flushed.
-			update_option( 'smaily_wp_connect_flush_rewrite_rules', true );
+			update_option( 'smaily_connect_flush_rewrite_rules', true );
 		}
 
 		$this->run_migrations();
@@ -64,21 +64,21 @@ class Lifecycle {
 	 */
 	private function set_scheduled_actions() {
 		// Check if the daily sync action is already scheduled.
-		if ( ! wp_next_scheduled( 'smaily_wp_connect_cron_sync_subscribers' ) ) {
+		if ( ! wp_next_scheduled( 'smaily_connect_cron_sync_subscribers' ) ) {
 			// Add Cron job to sync subscribers.
-			wp_schedule_event( time(), 'daily', 'smaily_wp_connect_cron_sync_subscribers' );
+			wp_schedule_event( time(), 'daily', 'smaily_connect_cron_sync_subscribers' );
 		}
 
 		// Check if the abandoned cart status action is already scheduled.
-		if ( ! wp_next_scheduled( 'smaily_wp_connect_cron_abandoned_carts_status' ) ) {
+		if ( ! wp_next_scheduled( 'smaily_connect_cron_abandoned_carts_status' ) ) {
 			// Schedule event to track abandoned statuses.
-			wp_schedule_event( time(), 'smaily_wp_connect_15_minutes', 'smaily_wp_connect_cron_abandoned_carts_status' );
+			wp_schedule_event( time(), 'smaily_connect_15_minutes', 'smaily_connect_cron_abandoned_carts_status' );
 		}
 
 		// Check if the abandoned cart email action is already scheduled.
-		if ( ! wp_next_scheduled( 'smaily_wp_connect_cron_abandoned_carts_email' ) ) {
+		if ( ! wp_next_scheduled( 'smaily_connect_cron_abandoned_carts_email' ) ) {
 			// Schedule event to send emails.
-			wp_schedule_event( time(), 'smaily_wp_connect_15_minutes', 'smaily_wp_connect_cron_abandoned_carts_email' );
+			wp_schedule_event( time(), 'smaily_connect_15_minutes', 'smaily_connect_cron_abandoned_carts_email' );
 		}
 	}
 
@@ -90,7 +90,7 @@ class Lifecycle {
 		if ( $plugin === 'woocommerce/woocommerce.php' ) {
 			$this->create_woocommerce_tables();
 			$this->set_scheduled_actions();
-			update_option( 'smaily_wp_connect_flush_rewrite_rules', true );
+			update_option( 'smaily_connect_flush_rewrite_rules', true );
 		}
 	}
 
@@ -131,9 +131,9 @@ class Lifecycle {
 		// Flush rewrite rules.
 		flush_rewrite_rules();
 		// Stop Cron.
-		wp_clear_scheduled_hook( 'smaily_wp_connect_cron_sync_subscribers' );
-		wp_clear_scheduled_hook( 'smaily_wp_connect_cron_abandoned_carts_email' );
-		wp_clear_scheduled_hook( 'smaily_wp_connect_cron_abandoned_carts_status' );
+		wp_clear_scheduled_hook( 'smaily_connect_cron_sync_subscribers' );
+		wp_clear_scheduled_hook( 'smaily_connect_cron_abandoned_carts_email' );
+		wp_clear_scheduled_hook( 'smaily_connect_cron_abandoned_carts_status' );
 		$this->logger->info( 'Plugin deactivated' );
 	}
 
@@ -154,7 +154,7 @@ class Lifecycle {
 
 		Options::delete_all_options();
 
-		delete_transient( 'smaily_wp_connect_plugin_updated' );
+		delete_transient( 'smaily_connect_plugin_updated' );
 	}
 
 	/**
@@ -164,11 +164,11 @@ class Lifecycle {
 	 *
 	 */
 	public function update() {
-		if ( get_transient( 'smaily_wp_connect_plugin_updated' ) !== true ) {
+		if ( get_transient( 'smaily_connect_plugin_updated' ) !== true ) {
 			return;
 		}
 		$this->run_migrations();
-		delete_transient( 'smaily_wp_connect_plugin_updated' );
+		delete_transient( 'smaily_connect_plugin_updated' );
 	}
 
 	/**
@@ -193,7 +193,7 @@ class Lifecycle {
 
 		foreach ( $updated_plugins as $plugin_basename ) {
 			if ( $smaily_basename === $plugin_basename ) {
-				return set_transient( 'smaily_wp_connect_plugin_updated', true );
+				return set_transient( 'smaily_connect_plugin_updated', true );
 			}
 		}
 	}

--- a/includes/smaily-logger.class.php
+++ b/includes/smaily-logger.class.php
@@ -3,7 +3,7 @@
  * Logger class for Smaily plugin logging.
  */
 
-namespace Smaily_WP_Connect\Includes;
+namespace Smaily_Connect\Includes;
 
 class Logger {
 	const LEVEL_INFO    = 'info';

--- a/includes/smaily-options.class.php
+++ b/includes/smaily-options.class.php
@@ -97,22 +97,22 @@ class Options {
 	 */
 	const RSS_DEFAULT_ORDER_BY = 'DESC';
 
-	const API_CREDENTIALS_OPTION                = 'smaily_wp_connect_api_credentials';
-	const SUBSCRIBER_SYNC_ENABLED_OPTION        = 'smaily_wp_connect_subscriber_sync_enabled';
-	const SUBSCRIBER_SYNC_FIELDS_OPTION         = 'smaily_wp_connect_subscriber_sync_fields';
-	const ABANDONED_CART_STATUS_OPTION          = 'smaily_wp_connect_abandoned_cart_status';
-	const ABANDONED_CART_CUTOFF_OPTION          = 'smaily_wp_connect_abandoned_cart_cutoff';
-	const ABANDONED_CART_FIELDS_OPTION          = 'smaily_wp_connect_abandoned_cart_fields';
-	const CHECKOUT_SUBSCRIPTION_ENABLED_OPTION  = 'smaily_wp_connect_checkout_subscription_enabled';
-	const CHECKOUT_SUBSCRIPTION_POSITION_OPTION = 'smaily_wp_connect_checkout_subscription_position';
-	const CHECKOUT_SUBSCRIPTION_LOCATION_OPTION = 'smaily_wp_connect_checkout_subscription_location';
-	const RSS_LIMIT_OPTION                      = 'smaily_wp_connect_rss_limit';
-	const RSS_CATEGORY_OPTION                   = 'smaily_wp_connect_rss_category';
-	const RSS_SORT_BY_OPTION                    = 'smaily_wp_connect_rss_sort_by';
-	const RSS_ORDER_BY_OPTION                   = 'smaily_wp_connect_rss_order_by';
-	const RSS_URL_OPTION                        = 'smaily_wp_connect_rss_url';
-	const DATABASE_VERSION_OPTION               = 'smaily_wp_connect_db_version';
-	const CONTACT_FORM_7_STATUS_OPTION          = 'smaily_wp_connect_cf7_status';
+	const API_CREDENTIALS_OPTION                = 'smaily_connect_api_credentials';
+	const SUBSCRIBER_SYNC_ENABLED_OPTION        = 'smaily_connect_subscriber_sync_enabled';
+	const SUBSCRIBER_SYNC_FIELDS_OPTION         = 'smaily_connect_subscriber_sync_fields';
+	const ABANDONED_CART_STATUS_OPTION          = 'smaily_connect_abandoned_cart_status';
+	const ABANDONED_CART_CUTOFF_OPTION          = 'smaily_connect_abandoned_cart_cutoff';
+	const ABANDONED_CART_FIELDS_OPTION          = 'smaily_connect_abandoned_cart_fields';
+	const CHECKOUT_SUBSCRIPTION_ENABLED_OPTION  = 'smaily_connect_checkout_subscription_enabled';
+	const CHECKOUT_SUBSCRIPTION_POSITION_OPTION = 'smaily_connect_checkout_subscription_position';
+	const CHECKOUT_SUBSCRIPTION_LOCATION_OPTION = 'smaily_connect_checkout_subscription_location';
+	const RSS_LIMIT_OPTION                      = 'smaily_connect_rss_limit';
+	const RSS_CATEGORY_OPTION                   = 'smaily_connect_rss_category';
+	const RSS_SORT_BY_OPTION                    = 'smaily_connect_rss_sort_by';
+	const RSS_ORDER_BY_OPTION                   = 'smaily_connect_rss_order_by';
+	const RSS_URL_OPTION                        = 'smaily_connect_rss_url';
+	const DATABASE_VERSION_OPTION               = 'smaily_connect_db_version';
+	const CONTACT_FORM_7_STATUS_OPTION          = 'smaily_connect_cf7_status';
 
 	/**
 	 * Array of all option fields.

--- a/includes/smaily-options.class.php
+++ b/includes/smaily-options.class.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Smaily_WP_Connect\Includes;
+namespace Smaily_Connect\Includes;
 
 class Options {
 	/**

--- a/includes/smaily-options.class.php
+++ b/includes/smaily-options.class.php
@@ -155,8 +155,8 @@ class Options {
 	 */
 	public static function get_checkout_subscription_position_options() {
 		return array(
-			'before' => __( 'Before', 'smaily-wp-connect' ),
-			'after'  => __( 'After', 'smaily-wp-connect' ),
+			'before' => __( 'Before', 'smaily-connect' ),
+			'after'  => __( 'After', 'smaily-connect' ),
 		);
 	}
 
@@ -179,10 +179,10 @@ class Options {
 	 */
 	public static function get_checkout_subscription_location_options() {
 		return array(
-			'account'  => __( 'Registration form', 'smaily-wp-connect' ),
-			'billing'  => __( 'Billing form', 'smaily-wp-connect' ),
-			'order'    => __( 'Order notes', 'smaily-wp-connect' ),
-			'shipping' => __( 'Shipping form', 'smaily-wp-connect' ),
+			'account'  => __( 'Registration form', 'smaily-connect' ),
+			'billing'  => __( 'Billing form', 'smaily-connect' ),
+			'order'    => __( 'Order notes', 'smaily-connect' ),
+			'shipping' => __( 'Shipping form', 'smaily-connect' ),
 		);
 	}
 

--- a/includes/smaily-widget.class.php
+++ b/includes/smaily-widget.class.php
@@ -38,7 +38,7 @@ class Widget extends WP_Widget {
 		// Allow overriding the template.
 		$template = locate_template( 'smaily/smaily-public-basic.php' );
 		if ( ! $template ) {
-			$template = SMAILY_WP_CONNECT_PLUGIN_PATH . 'public/partials/smaily-public-basic.php';
+			$template = SMAILY_CONNECT_PLUGIN_PATH . 'public/partials/smaily-public-basic.php';
 		}
 
 		$title = apply_filters( 'widget_title', empty( $instance['title'] ) ? '' : $instance['title'], $instance, $this->id_base );

--- a/includes/smaily-widget.class.php
+++ b/includes/smaily-widget.class.php
@@ -22,7 +22,7 @@ class Widget extends WP_Widget {
 	 */
 	public function __construct( Options $options ) {
 		$widget_ops = array( 'description' => __( 'Smaily Classic Subscription Widget', 'smaily-connect' ) );
-		parent::__construct( 'smaily_wp_connect_subscription_widget', __( 'Smaily Classic Subscription Widget', 'smaily-connect' ), $widget_ops );
+		parent::__construct( 'smaily_connect_subscription_widget', __( 'Smaily Classic Subscription Widget', 'smaily-connect' ), $widget_ops );
 
 		$this->options = $options;
 	}

--- a/includes/smaily-widget.class.php
+++ b/includes/smaily-widget.class.php
@@ -21,8 +21,8 @@ class Widget extends WP_Widget {
 	 * @param Options $options     Reference to options handler class.
 	 */
 	public function __construct( Options $options ) {
-		$widget_ops = array( 'description' => __( 'Smaily Classic Subscription Widget', 'smaily-wp-connect' ) );
-		parent::__construct( 'smaily_wp_connect_subscription_widget', __( 'Smaily Classic Subscription Widget', 'smaily-wp-connect' ), $widget_ops );
+		$widget_ops = array( 'description' => __( 'Smaily Classic Subscription Widget', 'smaily-connect' ) );
+		parent::__construct( 'smaily_wp_connect_subscription_widget', __( 'Smaily Classic Subscription Widget', 'smaily-connect' ), $widget_ops );
 
 		$this->options = $options;
 	}
@@ -123,26 +123,26 @@ class Widget extends WP_Widget {
 
 		?>
 		<p>
-			<label for="<?php echo esc_attr( $title_name ); ?>"><?php esc_html_e( 'Title', 'smaily-wp-connect' ); ?>:</label>
+			<label for="<?php echo esc_attr( $title_name ); ?>"><?php esc_html_e( 'Title', 'smaily-connect' ); ?>:</label>
 			<input class="widefat" id="<?php echo esc_attr( $title_id ); ?>" name="<?php echo esc_attr( $title_name ); ?>" type="text" value="<?php echo esc_attr( $instance['title'] ); ?>" />
 		</p>
 		<p>
 			<input class="checkbox" id="<?php echo esc_attr( $show_name_id ); ?>" name="<?php echo esc_attr( $show_name_name ); ?>" type="checkbox" <?php echo checked( $instance['show_name'] ); ?> value="1" />
-			<label for="<?php echo esc_attr( $show_name_id ); ?>"><?php esc_html_e( 'Display name field', 'smaily-wp-connect' ); ?></label>
+			<label for="<?php echo esc_attr( $show_name_id ); ?>"><?php esc_html_e( 'Display name field', 'smaily-connect' ); ?></label>
 		</p>
 		<p>
-			<label for="<?php echo esc_attr( $success_url_id ); ?>"><?php esc_html_e( 'Success URL', 'smaily-wp-connect' ); ?>:</label>
+			<label for="<?php echo esc_attr( $success_url_id ); ?>"><?php esc_html_e( 'Success URL', 'smaily-connect' ); ?>:</label>
 			<input id="<?php echo esc_attr( $success_url_id ); ?>" name="<?php echo esc_attr( $success_url_name ); ?>" type="text" value="<?php echo esc_url( $instance['success_url'] ); ?>" />
 		</p>
 		<p>
-			<label for="<?php echo esc_attr( $failure_url_id ); ?>"><?php esc_html_e( 'Failure URL', 'smaily-wp-connect' ); ?>:</label>
+			<label for="<?php echo esc_attr( $failure_url_id ); ?>"><?php esc_html_e( 'Failure URL', 'smaily-connect' ); ?>:</label>
 			<input id="<?php echo esc_attr( $failure_url_id ); ?>" name="<?php echo esc_attr( $failure_url_name ); ?>" type="text" value="<?php echo esc_url( $instance['failure_url'] ); ?>" />
 		</p>
-		<?php esc_html_e( 'Note: URLs are optional. If left empty, the current page URL will be used.', 'smaily-wp-connect' ); ?>
+		<?php esc_html_e( 'Note: URLs are optional. If left empty, the current page URL will be used.', 'smaily-connect' ); ?>
 		<p>
-			<label for="<?php echo esc_attr( $autoresponder_id ); ?>"><?php esc_html_e( 'Autoresponder ID', 'smaily-wp-connect' ); ?>:</label>
+			<label for="<?php echo esc_attr( $autoresponder_id ); ?>"><?php esc_html_e( 'Autoresponder ID', 'smaily-connect' ); ?>:</label>
 			<select id="<?php echo esc_attr( $autoresponder_id ); ?>" name="<?php echo esc_attr( $autoresponder_id_name ); ?>">
-				<option value=""><?php esc_html_e( 'No autoresponder', 'smaily-wp-connect' ); ?></option>
+				<option value=""><?php esc_html_e( 'No autoresponder', 'smaily-connect' ); ?></option>
 				<?php foreach ( $autoresponders as $id => $title ) : ?>
 					<option value="<?php echo esc_attr( $id ); ?>" <?php selected( $instance['autoresponder_id'], $id ); ?>><?php echo esc_attr( $title ); ?></option>
 				<?php endforeach; ?>

--- a/includes/smaily-widget.class.php
+++ b/includes/smaily-widget.class.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Smaily_WP_Connect\Includes;
+namespace Smaily_Connect\Includes;
 
-use Smaily_WP_Connect\Public_Base;
+use Smaily_Connect\Public_Base;
 use WP_Widget;
 
 class Widget extends WP_Widget {

--- a/includes/smaily.class.php
+++ b/includes/smaily.class.php
@@ -199,36 +199,36 @@ class Smaily_WP_Connect {
 	 * @access private
 	 */
 	private function load_dependencies() {
-		require_once SMAILY_WP_CONNECT_PLUGIN_PATH . 'admin/smaily-admin-renderer.class.php';
-		require_once SMAILY_WP_CONNECT_PLUGIN_PATH . 'admin/smaily-admin-sanitizer.class.php';
-		require_once SMAILY_WP_CONNECT_PLUGIN_PATH . 'admin/smaily-admin-settings.class.php';
-		require_once SMAILY_WP_CONNECT_PLUGIN_PATH . 'admin/smaily-admin.class.php';
-		require_once SMAILY_WP_CONNECT_PLUGIN_PATH . 'blocks/newsletter-signup/smaily-integration.class.php';
-		require_once SMAILY_WP_CONNECT_PLUGIN_PATH . 'includes/smaily-api.class.php';
-		require_once SMAILY_WP_CONNECT_PLUGIN_PATH . 'includes/smaily-blocks.class.php';
-		require_once SMAILY_WP_CONNECT_PLUGIN_PATH . 'includes/smaily-cypher.class.php';
-		require_once SMAILY_WP_CONNECT_PLUGIN_PATH . 'includes/smaily-helper.class.php';
-		require_once SMAILY_WP_CONNECT_PLUGIN_PATH . 'includes/smaily-logger.class.php';
-		require_once SMAILY_WP_CONNECT_PLUGIN_PATH . 'includes/smaily-options.class.php';
-		require_once SMAILY_WP_CONNECT_PLUGIN_PATH . 'includes/smaily-client.class.php';
-		require_once SMAILY_WP_CONNECT_PLUGIN_PATH . 'includes/smaily-widget.class.php';
-		require_once SMAILY_WP_CONNECT_PLUGIN_PATH . 'public/smaily-public.class.php';
+		require_once SMAILY_CONNECT_PLUGIN_PATH . 'admin/smaily-admin-renderer.class.php';
+		require_once SMAILY_CONNECT_PLUGIN_PATH . 'admin/smaily-admin-sanitizer.class.php';
+		require_once SMAILY_CONNECT_PLUGIN_PATH . 'admin/smaily-admin-settings.class.php';
+		require_once SMAILY_CONNECT_PLUGIN_PATH . 'admin/smaily-admin.class.php';
+		require_once SMAILY_CONNECT_PLUGIN_PATH . 'blocks/newsletter-signup/smaily-integration.class.php';
+		require_once SMAILY_CONNECT_PLUGIN_PATH . 'includes/smaily-api.class.php';
+		require_once SMAILY_CONNECT_PLUGIN_PATH . 'includes/smaily-blocks.class.php';
+		require_once SMAILY_CONNECT_PLUGIN_PATH . 'includes/smaily-cypher.class.php';
+		require_once SMAILY_CONNECT_PLUGIN_PATH . 'includes/smaily-helper.class.php';
+		require_once SMAILY_CONNECT_PLUGIN_PATH . 'includes/smaily-logger.class.php';
+		require_once SMAILY_CONNECT_PLUGIN_PATH . 'includes/smaily-options.class.php';
+		require_once SMAILY_CONNECT_PLUGIN_PATH . 'includes/smaily-client.class.php';
+		require_once SMAILY_CONNECT_PLUGIN_PATH . 'includes/smaily-widget.class.php';
+		require_once SMAILY_CONNECT_PLUGIN_PATH . 'public/smaily-public.class.php';
 
 		$this->options = new Options();
 
 		if ( Helper::is_woocommerce_active() ) {
-			require_once SMAILY_WP_CONNECT_PLUGIN_PATH . 'integrations/woocommerce/cart.class.php';
-			require_once SMAILY_WP_CONNECT_PLUGIN_PATH . 'integrations/woocommerce/cron.class.php';
-			require_once SMAILY_WP_CONNECT_PLUGIN_PATH . 'integrations/woocommerce/data-handler.class.php';
-			require_once SMAILY_WP_CONNECT_PLUGIN_PATH . 'integrations/woocommerce/profile-settings.class.php';
-			require_once SMAILY_WP_CONNECT_PLUGIN_PATH . 'integrations/woocommerce/rss.class.php';
-			require_once SMAILY_WP_CONNECT_PLUGIN_PATH . 'integrations/woocommerce/subscriber-synchronization.class.php';
+			require_once SMAILY_CONNECT_PLUGIN_PATH . 'integrations/woocommerce/cart.class.php';
+			require_once SMAILY_CONNECT_PLUGIN_PATH . 'integrations/woocommerce/cron.class.php';
+			require_once SMAILY_CONNECT_PLUGIN_PATH . 'integrations/woocommerce/data-handler.class.php';
+			require_once SMAILY_CONNECT_PLUGIN_PATH . 'integrations/woocommerce/profile-settings.class.php';
+			require_once SMAILY_CONNECT_PLUGIN_PATH . 'integrations/woocommerce/rss.class.php';
+			require_once SMAILY_CONNECT_PLUGIN_PATH . 'integrations/woocommerce/subscriber-synchronization.class.php';
 		}
 
 		if ( Helper::is_cf7_active() ) {
-			require_once SMAILY_WP_CONNECT_PLUGIN_PATH . 'integrations/cf7/admin.class.php';
-			require_once SMAILY_WP_CONNECT_PLUGIN_PATH . 'integrations/cf7/public.class.php';
-			require_once SMAILY_WP_CONNECT_PLUGIN_PATH . 'integrations/cf7/service.class.php';
+			require_once SMAILY_CONNECT_PLUGIN_PATH . 'integrations/cf7/admin.class.php';
+			require_once SMAILY_CONNECT_PLUGIN_PATH . 'integrations/cf7/public.class.php';
+			require_once SMAILY_CONNECT_PLUGIN_PATH . 'integrations/cf7/service.class.php';
 		}
 	}
 

--- a/includes/smaily.class.php
+++ b/includes/smaily.class.php
@@ -1,21 +1,21 @@
 <?php
 
-use Smaily_WP_Connect\Admin;
-use Smaily_WP_Connect\Includes\API;
-use Smaily_WP_Connect\Includes\Blocks;
-use Smaily_WP_Connect\Includes\Helper;
-use Smaily_WP_Connect\Includes\Lifecycle;
-use Smaily_WP_Connect\Includes\Options;
-use Smaily_WP_Connect\Integrations\CF7\Admin as Smaily_CF7_Admin;
-use Smaily_WP_Connect\Integrations\CF7\Public_Base as Smaily_CF7_Public;
-use Smaily_WP_Connect\Integrations\WooCommerce\Cart;
-use Smaily_WP_Connect\Integrations\WooCommerce\Cron;
-use Smaily_WP_Connect\Integrations\WooCommerce\Profile_Settings;
-use Smaily_WP_Connect\Integrations\WooCommerce\Rss;
-use Smaily_WP_Connect\Integrations\WooCommerce\Subscriber_Synchronization;
-use Smaily_WP_Connect\Public_Base;
+use Smaily_Connect\Admin;
+use Smaily_Connect\Includes\API;
+use Smaily_Connect\Includes\Blocks;
+use Smaily_Connect\Includes\Helper;
+use Smaily_Connect\Includes\Lifecycle;
+use Smaily_Connect\Includes\Options;
+use Smaily_Connect\Integrations\CF7\Admin as Smaily_CF7_Admin;
+use Smaily_Connect\Integrations\CF7\Public_Base as Smaily_CF7_Public;
+use Smaily_Connect\Integrations\WooCommerce\Cart;
+use Smaily_Connect\Integrations\WooCommerce\Cron;
+use Smaily_Connect\Integrations\WooCommerce\Profile_Settings;
+use Smaily_Connect\Integrations\WooCommerce\Rss;
+use Smaily_Connect\Integrations\WooCommerce\Subscriber_Synchronization;
+use Smaily_Connect\Public_Base;
 
-class Smaily_WP_Connect {
+class Smaily_Connect {
 	/**
 	 * The unique identifier of this plugin.
 	 *

--- a/integrations/cf7/admin.class.php
+++ b/integrations/cf7/admin.class.php
@@ -94,7 +94,7 @@ class Admin {
 	public function add_tab( $panels ) {
 		$panel = array(
 			'smailyforcf7' => array(
-				'title'    => __( 'Smaily for Contact Form 7', 'smaily-wp-connect' ),
+				'title'    => __( 'Smaily for Contact Form 7', 'smaily-connect' ),
 				'callback' => array( $this, 'panel_content' ),
 			),
 		);

--- a/integrations/cf7/admin.class.php
+++ b/integrations/cf7/admin.class.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Smaily_WP_Connect\Integrations\CF7;
+namespace Smaily_Connect\Integrations\CF7;
 
-use Smaily_WP_Connect\Includes\Helper;
-use Smaily_WP_Connect\Includes\Options;
+use Smaily_Connect\Includes\Helper;
+use Smaily_Connect\Includes\Options;
 use WPCF7_ContactForm;
 use WPCF7_Integration;
 

--- a/integrations/cf7/admin.class.php
+++ b/integrations/cf7/admin.class.php
@@ -121,7 +121,7 @@ class Admin {
 		$form_tags       = \WPCF7_FormTagsManager::get_instance()->get_scanned_tags();
 		$captcha_enabled = $this->is_captcha_enabled( $form_tags );
 
-		require_once SMAILY_WP_CONNECT_PLUGIN_PATH . 'integrations/cf7/partials/smaily-cf7-admin.php';
+		require_once SMAILY_CONNECT_PLUGIN_PATH . 'integrations/cf7/partials/smaily-cf7-admin.php';
 	}
 
 	/**

--- a/integrations/cf7/partials/smaily-cf7-admin.php
+++ b/integrations/cf7/partials/smaily-cf7-admin.php
@@ -12,24 +12,24 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<?php
 			esc_html_e(
 				'Configuring Smaily integration is disabled when using "Add New Form". Please save this form or edit an already existing form',
-				'smaily-wp-connect'
+				'smaily-connect'
 			);
 			?>
 		</p>
 	</div>
 <?php else : ?>
 	<p id='smailyforcf7-captcha-error' style='padding:15px; background-color:#ffdf92; margin:0 0 10px; display:<?php echo $has_credentials ? 'none' : 'block'; ?>'>
-		<?php esc_html_e( 'Please authenticate Smaily credentials under Smaily Settings.', 'smaily-wp-connect' ); ?>
+		<?php esc_html_e( 'Please authenticate Smaily credentials under Smaily Settings.', 'smaily-connect' ); ?>
 	</p>
 	<div id='smailyforcf7-credentials-valid' style='display:<?php echo $has_credentials ? 'block' : 'none'; ?>'>
 		<p id='smailyforcf7-captcha-error' style='padding:15px; background-color:#ffdf92; margin:0 0 10px; display:<?php echo $captcha_enabled ? 'none' : 'block'; ?>'>
-			<?php esc_html_e( 'CAPTCHA disabled. Please use a CAPTCHA if this is a public site.', 'smaily-wp-connect' ); ?>
+			<?php esc_html_e( 'CAPTCHA disabled. Please use a CAPTCHA if this is a public site.', 'smaily-connect' ); ?>
 		</p>
 		<table class='autoresponders-table' style='margin:15px'>
 			<tr class="form-field">
 				<th scope="row" style="text-align:left;padding:10px;">
 					<label for="smaily_status">
-						<?php esc_html_e( 'Enable Smaily for this form', 'smaily-wp-connect' ); ?>
+						<?php esc_html_e( 'Enable Smaily for this form', 'smaily-connect' ); ?>
 					</label>
 				</th>
 				<td>
@@ -39,12 +39,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 			</tr>
 			<tr id='smailyforcf7-autoresponders' class='form-field'>
 				<th style="text-align:left;padding:10px;">
-					<?php esc_html_e( 'Autoresponder', 'smaily-wp-connect' ); ?>
+					<?php esc_html_e( 'Autoresponder', 'smaily-connect' ); ?>
 				</th>
 				<td>
 					<select id='smailyforcf7-autoresponder-select' name='smailyforcf7-autoresponder'>
 						<option value='' <?php echo $default_autoresponder === 0 ? 'selected="selected"' : ''; ?>>
-							<?php esc_html_e( 'No autoresponder', 'smaily-wp-connect' ); ?>
+							<?php esc_html_e( 'No autoresponder', 'smaily-connect' ); ?>
 						</option>
 						<?php foreach ( $autoresponder_list as $autoresponder_id => $autoresponder_title ) : ?>
 							<option value='<?php echo esc_html( $autoresponder_id ); ?>'

--- a/integrations/cf7/public.class.php
+++ b/integrations/cf7/public.class.php
@@ -106,17 +106,17 @@ class Public_Base {
 		$response = $request->trigger_automation( (int) $cf7_settings['autoresponder_id'], array( $payload ) );
 
 		if ( empty( $response['body'] ) ) {
-			$error_message = esc_html__( 'Something went wrong', 'smaily-wp-connect' );
+			$error_message = esc_html__( 'Something went wrong', 'smaily-connect' );
 		} elseif ( 101 !== (int) $response['body']['code'] ) {
 			switch ( $response['body']['code'] ) {
 				case 201:
-					$error_message = esc_html__( 'Form was not submitted using POST method.', 'smaily-wp-connect' );
+					$error_message = esc_html__( 'Form was not submitted using POST method.', 'smaily-connect' );
 					break;
 				case 204:
-					$error_message = esc_html__( 'Input does not contain a valid email address.', 'smaily-wp-connect' );
+					$error_message = esc_html__( 'Input does not contain a valid email address.', 'smaily-connect' );
 					break;
 				default:
-					$error_message = esc_html__( 'Subscribing failed with unknown reason.', 'smaily-wp-connect' );
+					$error_message = esc_html__( 'Subscribing failed with unknown reason.', 'smaily-connect' );
 					break;
 			}
 		}

--- a/integrations/cf7/public.class.php
+++ b/integrations/cf7/public.class.php
@@ -87,7 +87,7 @@ class Public_Base {
 				$payload['email'] = ! is_null( $posted_value ) ? $posted_value : '';
 			} elseif ( $is_single_option_radio || $is_single_option_menu ) {
 				// Single option dropdown menu and radio button can only have one value.
-				$payload[ $this->format_field( $tag->name ) ] = $tag->values[0];
+				$payload[ $this->format_field( $tag->name ) ] = $posted_value[0] ?? '';
 			} elseif ( $tag->basetype === 'select' || $tag->basetype === 'radio' || $tag->basetype === 'checkbox' ) {
 				// Tags with multiple options need to have default values, because browsers do not send values of unchecked inputs.
 				foreach ( $tag->values as $value ) {
@@ -111,6 +111,9 @@ class Public_Base {
 			switch ( $response['body']['code'] ) {
 				case 201:
 					$error_message = esc_html__( 'Form was not submitted using POST method.', 'smaily-connect' );
+					break;
+				case 203:
+					$error_message = esc_html__( 'Invalid data submitted.', 'smaily-connect' );
 					break;
 				case 204:
 					$error_message = esc_html__( 'Input does not contain a valid email address.', 'smaily-connect' );

--- a/integrations/cf7/public.class.php
+++ b/integrations/cf7/public.class.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Smaily_WP_Connect\Integrations\CF7;
+namespace Smaily_Connect\Integrations\CF7;
 
-use Smaily_WP_Connect\Includes\Helper;
-use Smaily_WP_Connect\Includes\Options;
-use Smaily_WP_Connect\Includes\Smaily_Client;
+use Smaily_Connect\Includes\Helper;
+use Smaily_Connect\Includes\Options;
+use Smaily_Connect\Includes\Smaily_Client;
 use Transliterator;
 use WPCF7_ContactForm;
 use WPCF7_Submission;

--- a/integrations/cf7/service.class.php
+++ b/integrations/cf7/service.class.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Smaily_WP_Connect\Integrations\CF7;
+namespace Smaily_Connect\Integrations\CF7;
 
 class_exists( 'WPCF7_Service' ) || exit;
 
 use WPCF7_Service;
-use Smaily_WP_Connect\Includes\Options;
+use Smaily_Connect\Includes\Options;
 
 class Service extends WPCF7_Service {
 	/**

--- a/integrations/cf7/service.class.php
+++ b/integrations/cf7/service.class.php
@@ -36,7 +36,7 @@ class Service extends WPCF7_Service {
 	}
 
 	public function get_title() {
-		return __( 'Smaily WP Connect', 'smaily-wp-connect' );
+		return __( 'Smaily WP Connect', 'smaily-connect' );
 	}
 
 	public function is_active() {
@@ -58,7 +58,7 @@ class Service extends WPCF7_Service {
 		$args = wp_parse_args( $args, array() );
 
 		$url = menu_page_url( $this->plugin_name, false );
-		$url = add_query_arg( array( 'service' => 'smaily-wp-connect' ), $url );
+		$url = add_query_arg( array( 'service' => 'smaily-connect' ), $url );
 
 		if ( ! empty( $args ) ) {
 			$url = add_query_arg( $args, $url );
@@ -74,23 +74,23 @@ class Service extends WPCF7_Service {
 	public function display( $action = '' ) {
 		?>
 		<p>
-			<?php esc_html_e( 'Smaily email marketing and automation plugin for Contact Form 7 allows you to automatically add newsletter subscribers to your Smaily subscriber list, by using forms created in Contact Form 7.', 'smaily-wp-connect' ); ?>
+			<?php esc_html_e( 'Smaily email marketing and automation plugin for Contact Form 7 allows you to automatically add newsletter subscribers to your Smaily subscriber list, by using forms created in Contact Form 7.', 'smaily-connect' ); ?>
 		</p>
 		<p>
 			<strong>
 				<a href="https://smaily.com/integrations/smaily-for-contact-form-7">
-					<?php esc_html_e( 'Smaily integration', 'smaily-wp-connect' ); ?>
+					<?php esc_html_e( 'Smaily integration', 'smaily-connect' ); ?>
 				</a>
 			</strong>
 		</p>
 		<?php if ( $this->is_active() ) : ?>
 			<p class="dashicons-before dashicons-yes">
-				<?php esc_html_e( 'Smaily integration is active on this site.', 'smaily-wp-connect' ); ?>
+				<?php esc_html_e( 'Smaily integration is active on this site.', 'smaily-connect' ); ?>
 			</p>
 		<?php endif ?>
 		<p>
 			<a class="button" href="<?php echo esc_url( menu_page_url( $this->plugin_name, false ) ); ?>">
-				<?php esc_html_e( 'Setup integration', 'smaily-wp-connect' ); ?>
+				<?php esc_html_e( 'Setup integration', 'smaily-connect' ); ?>
 			</a>
 		</p>
 		<?php

--- a/integrations/cf7/service.class.php
+++ b/integrations/cf7/service.class.php
@@ -36,7 +36,7 @@ class Service extends WPCF7_Service {
 	}
 
 	public function get_title() {
-		return __( 'Smaily WP Connect', 'smaily-connect' );
+		return __( 'Smaily Connect', 'smaily-connect' );
 	}
 
 	public function is_active() {

--- a/integrations/woocommerce/cart.class.php
+++ b/integrations/woocommerce/cart.class.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Smaily_WP_Connect\Integrations\WooCommerce;
+namespace Smaily_Connect\Integrations\WooCommerce;
 
-use Smaily_WP_Connect\Includes\Helper;
+use Smaily_Connect\Includes\Helper;
 
 class Cart {
 	/**

--- a/integrations/woocommerce/cart.class.php
+++ b/integrations/woocommerce/cart.class.php
@@ -8,7 +8,7 @@ class Cart {
 	/**
 	 * Abandoned cart table name.
 	 */
-	const ABANDONED_CART_TABLE_NAME = 'smaily_wp_connect_abandoned_carts';
+	const ABANDONED_CART_TABLE_NAME = 'smaily_connect_abandoned_carts';
 
 	/**
 	 * Constructor.
@@ -55,14 +55,14 @@ class Cart {
 		}
 
 		// Check if the function has already run in this request.
-		if ( get_transient( 'smaily_wp_connect_cart_updated' ) ) {
+		if ( get_transient( 'smaily_connect_cart_updated' ) ) {
 			return;
 		}
 
 		/**
 		 * Set a transient to prevent multiple calls in a small duration.
 		 */
-		set_transient( 'smaily_wp_connect_cart_updated', true, 1 );
+		set_transient( 'smaily_connect_cart_updated', true, 1 );
 
 		global $wpdb;
 		// Customer data.

--- a/integrations/woocommerce/cron.class.php
+++ b/integrations/woocommerce/cron.class.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Smaily_WP_Connect\Integrations\WooCommerce;
+namespace Smaily_Connect\Integrations\WooCommerce;
 
-use Smaily_WP_Connect\Includes\Helper;
-use Smaily_WP_Connect\Includes\Logger;
-use Smaily_WP_Connect\Includes\Options;
-use Smaily_WP_Connect\Includes\Smaily_Client;
+use Smaily_Connect\Includes\Helper;
+use Smaily_Connect\Includes\Logger;
+use Smaily_Connect\Includes\Options;
+use Smaily_Connect\Includes\Smaily_Client;
 use WC_Product;
 use WP_User;
 

--- a/integrations/woocommerce/cron.class.php
+++ b/integrations/woocommerce/cron.class.php
@@ -46,11 +46,11 @@ class Cron {
 		// Register the custom schedule early
 		add_filter( 'cron_schedules', array( $this, 'smaily_cron_schedules' ) );
 		// Action hook for subscriber synchronization.
-		add_action( 'smaily_wp_connect_cron_sync_subscribers', array( $this, 'smaily_sync_subscribers' ) );
+		add_action( 'smaily_connect_cron_sync_subscribers', array( $this, 'smaily_sync_subscribers' ) );
 		// Cron for updating abandoned cart statuses.
-		add_action( 'smaily_wp_connect_cron_abandoned_carts_status', array( $this, 'smaily_abandoned_carts_status' ) );
+		add_action( 'smaily_connect_cron_abandoned_carts_status', array( $this, 'smaily_abandoned_carts_status' ) );
 		// Cron for sending abandoned cart emails.
-		add_action( 'smaily_wp_connect_cron_abandoned_carts_email', array( $this, 'smaily_abandoned_carts_email' ) );
+		add_action( 'smaily_connect_cron_abandoned_carts_email', array( $this, 'smaily_abandoned_carts_email' ) );
 	}
 
 	/**
@@ -60,7 +60,7 @@ class Cron {
 	 * @return array $schedules Updated array.
 	 */
 	public function smaily_cron_schedules( $schedules ) {
-		$schedules['smaily_wp_connect_15_minutes'] = array(
+		$schedules['smaily_connect_15_minutes'] = array(
 			'interval' => 900,
 			'display'  => esc_html__( 'In every 15 minutes', 'smaily-connect' ),
 		);

--- a/integrations/woocommerce/cron.class.php
+++ b/integrations/woocommerce/cron.class.php
@@ -62,7 +62,7 @@ class Cron {
 	public function smaily_cron_schedules( $schedules ) {
 		$schedules['smaily_wp_connect_15_minutes'] = array(
 			'interval' => 900,
-			'display'  => esc_html__( 'In every 15 minutes', 'smaily-wp-connect' ),
+			'display'  => esc_html__( 'In every 15 minutes', 'smaily-connect' ),
 		);
 
 		return $schedules;

--- a/integrations/woocommerce/data-handler.class.php
+++ b/integrations/woocommerce/data-handler.class.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Smaily_WP_Connect\Integrations\WooCommerce;
+namespace Smaily_Connect\Integrations\WooCommerce;
 
-use Smaily_WP_Connect\Includes\Options;
-use Smaily_WP_Connect\Includes\Helper;
+use Smaily_Connect\Includes\Options;
+use Smaily_Connect\Includes\Helper;
 
 class Data_Handler {
 	/**

--- a/integrations/woocommerce/profile-settings.class.php
+++ b/integrations/woocommerce/profile-settings.class.php
@@ -109,8 +109,8 @@ class Profile_Settings {
 	public function smaily_print_user_admin_fields() {
 		$fields = $this->get_fields();
 		?>
-		<h2><?php esc_html_e( 'Additional Information', 'smaily-wp-connect' ); ?></h2>
-		<table class="form-table" id="smaily-wp-connect-additional-information">
+		<h2><?php esc_html_e( 'Additional Information', 'smaily-connect' ); ?></h2>
+		<table class="form-table" id="smaily-connect-additional-information">
 			<?php foreach ( $fields as $key => $field_args ) { ?>
 				<?php
 				if ( ! empty( $field_args['hide_in_admin'] ) ) {
@@ -367,12 +367,12 @@ class Profile_Settings {
 			$fields = array(
 				'user_gender'     => array(
 					'type'                 => 'radio',
-					'label'                => __( 'Gender', 'smaily-wp-connect' ),
+					'label'                => __( 'Gender', 'smaily-connect' ),
 					'required'             => false,
 					'class'                => array( 'tog' ),
 					'options'              => array(
-						1 => __( 'Male', 'smaily-wp-connect' ),
-						2 => __( 'Female', 'smaily-wp-connect' ),
+						1 => __( 'Male', 'smaily-connect' ),
+						2 => __( 'Female', 'smaily-connect' ),
 					),
 					'hide_in_account'      => false,
 					'hide_in_admin'        => false,
@@ -381,8 +381,8 @@ class Profile_Settings {
 				),
 				'user_phone'      => array(
 					'type'                 => 'tel',
-					'label'                => __( 'Phone', 'smaily-wp-connect' ),
-					'placeholder'          => __( 'Enter phone number', 'smaily-wp-connect' ),
+					'label'                => __( 'Phone', 'smaily-connect' ),
+					'placeholder'          => __( 'Enter phone number', 'smaily-connect' ),
 					'required'             => false,
 					'class'                => array( 'regular-text' ),
 					'hide_in_account'      => false,
@@ -392,8 +392,8 @@ class Profile_Settings {
 				),
 				'user_dob'        => array(
 					'type'                 => 'date',
-					'label'                => __( 'Birthday', 'smaily-wp-connect' ),
-					'placeholder'          => __( 'Enter birthday', 'smaily-wp-connect' ),
+					'label'                => __( 'Birthday', 'smaily-connect' ),
+					'placeholder'          => __( 'Enter birthday', 'smaily-connect' ),
 					'required'             => false,
 					'class'                => array( 'regular-text' ),
 					'hide_in_account'      => false,
@@ -403,7 +403,7 @@ class Profile_Settings {
 				),
 				'user_newsletter' => array(
 					'type'                 => 'checkbox',
-					'label'                => __( 'Subscribe to newsletter', 'smaily-wp-connect' ),
+					'label'                => __( 'Subscribe to newsletter', 'smaily-connect' ),
 					'required'             => false,
 					'hide_in_account'      => false,
 					'hide_in_admin'        => false,

--- a/integrations/woocommerce/profile-settings.class.php
+++ b/integrations/woocommerce/profile-settings.class.php
@@ -413,7 +413,7 @@ class Profile_Settings {
 			);
 
 			$enabled_fields = $this->filter_enabled_fields( $fields );
-			$this->fields   = apply_filters( 'smaily_wp_connect_account_fields', $enabled_fields );
+			$this->fields   = apply_filters( 'smaily_connect_account_fields', $enabled_fields );
 		}
 
 		return $this->fields;

--- a/integrations/woocommerce/profile-settings.class.php
+++ b/integrations/woocommerce/profile-settings.class.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Smaily_WP_Connect\Integrations\WooCommerce;
+namespace Smaily_Connect\Integrations\WooCommerce;
 
-use Smaily_WP_Connect\Includes\Options;
+use Smaily_Connect\Includes\Options;
 
 class Profile_Settings {
 	/**

--- a/integrations/woocommerce/rss.class.php
+++ b/integrations/woocommerce/rss.class.php
@@ -100,9 +100,9 @@ class Rss {
 
 		// Render products RSS feed, if requested.
 		if ( $render_rss_feed === true ) {
-			return SMAILY_WP_CONNECT_PLUGIN_PATH . 'public/template/smaily-rss-feed.php';
+			return SMAILY_CONNECT_PLUGIN_PATH . 'public/template/smaily-rss-feed.php';
 		} elseif ( $pagename === 'smaily-rss-feed' ) {
-			return SMAILY_WP_CONNECT_PLUGIN_PATH . 'public/template/smaily-rss-feed.php';
+			return SMAILY_CONNECT_PLUGIN_PATH . 'public/template/smaily-rss-feed.php';
 		}
 
 		// Load normal template as a fallback.

--- a/integrations/woocommerce/rss.class.php
+++ b/integrations/woocommerce/rss.class.php
@@ -113,9 +113,9 @@ class Rss {
 	 * Conditionally flush rewrite rules.
 	 */
 	public function maybe_flush_rewrite_rules() {
-		if ( get_option( 'smaily_wp_connect_flush_rewrite_rules' ) ) {
+		if ( get_option( 'smaily_connect_flush_rewrite_rules' ) ) {
 			flush_rewrite_rules();
-			delete_option( 'smaily_wp_connect_flush_rewrite_rules' );
+			delete_option( 'smaily_connect_flush_rewrite_rules' );
 		}
 	}
 

--- a/integrations/woocommerce/rss.class.php
+++ b/integrations/woocommerce/rss.class.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Smaily_WP_Connect\Integrations\WooCommerce;
+namespace Smaily_Connect\Integrations\WooCommerce;
 
 use WC_Product;
 

--- a/integrations/woocommerce/subscriber-synchronization.class.php
+++ b/integrations/woocommerce/subscriber-synchronization.class.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Smaily_WP_Connect\Integrations\WooCommerce;
+namespace Smaily_Connect\Integrations\WooCommerce;
 
-use Smaily_WP_Connect\Blocks\Checkout_Optin\Extend_Store_Endpoint;
-use Smaily_WP_Connect\Includes\Helper;
-use Smaily_WP_Connect\Includes\Logger;
-use Smaily_WP_Connect\Includes\Options;
-use Smaily_WP_Connect\Includes\Smaily_Client;
+use Smaily_Connect\Blocks\Checkout_Optin\Extend_Store_Endpoint;
+use Smaily_Connect\Includes\Helper;
+use Smaily_Connect\Includes\Logger;
+use Smaily_Connect\Includes\Options;
+use Smaily_Connect\Includes\Smaily_Client;
 use WC_Order;
 use WP_REST_Request;
 

--- a/languages/smaily-connect-et.po
+++ b/languages/smaily-connect-et.po
@@ -77,7 +77,7 @@ msgstr "Sünkroniseerige uudiskirjaga liitujaid automaatselt kasutades igapäeva
 
 #: integrations/cf7/partials/smaily-cf7-admin.php:42
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:268
+#: blocks/newsletter-signup/src/edit.js:265
 msgid "Autoresponder"
 msgstr "Automaatvastaja"
 
@@ -103,7 +103,7 @@ msgid "Build your own from component."
 msgstr "Ehitage vorm ise."
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:225
+#: blocks/newsletter-signup/src/edit.js:222
 msgid "Button border radius"
 msgstr "Nupu piirjoone raadius"
 
@@ -182,8 +182,8 @@ msgid "Daily Automatic Subscriber Synchronization"
 msgstr "Igapäevane Automaatne Uudiskirjaga Liitujate Sünkroniseerimine"
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:258
-#: blocks/newsletter-signup/src/edit.js:265
+#: blocks/newsletter-signup/src/edit.js:255
+#: blocks/newsletter-signup/src/edit.js:262
 msgid "Defaults to current page URL."
 msgstr "Vaikimisi praeguse lehekülje URL."
 
@@ -197,7 +197,7 @@ msgstr "Ühenda lahti"
 
 #: includes/smaily-widget.class.php:131
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:177
+#: blocks/newsletter-signup/src/edit.js:174
 msgid "Display name field"
 msgstr "Kuva nime väli"
 
@@ -213,7 +213,7 @@ msgid "Email"
 msgstr "E-post"
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:197
+#: blocks/newsletter-signup/src/edit.js:194
 msgid "Email field label"
 msgstr "E-posti välja silt"
 
@@ -251,13 +251,13 @@ msgid "Enter phone number"
 msgstr "Sisestage telefoninumber"
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:243
+#: blocks/newsletter-signup/src/edit.js:240
 msgid "Error message"
 msgstr "Veateade"
 
 #: includes/smaily-widget.class.php:138
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:261
+#: blocks/newsletter-signup/src/edit.js:258
 msgid "Failure URL"
 msgstr "Tõrke URL"
 
@@ -289,7 +289,7 @@ msgid "Form was not submitted using POST method."
 msgstr "Vormi ei saadetud POST meetodit kasutades."
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:213
+#: blocks/newsletter-signup/src/edit.js:210
 msgid "Full width subscribe button"
 msgstr "Täislaiuses liitumisnupp"
 
@@ -307,7 +307,7 @@ msgid "Getting started"
 msgstr "Alustamine"
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:112
+#: blocks/newsletter-signup/src/edit.js:109
 msgid "Go to plugin settings"
 msgstr "Minge pistikprogrammi seadetesse"
 
@@ -316,7 +316,7 @@ msgid "here"
 msgstr "siin"
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:250
+#: blocks/newsletter-signup/src/edit.js:247
 msgid "Hidden fields"
 msgstr "Peidetud väljad"
 
@@ -332,10 +332,6 @@ msgstr "Kuidas luua API ligipääsu?"
 #: smaily-connect.php
 msgid "https://smaily.com"
 msgstr "https://smaily.com"
-
-#: admin/smaily-admin-renderer.class.php:114
-msgid "https://smaily.com/help/how-to/ecommerce-integrations/smaily-plugin-for-wordpress#toc-heading-4"
-msgstr "https://smaily.com/help/how-to/ecommerce-integrations/smaily-plugin-for-wordpress#toc-heading-4"
 
 #: admin/smaily-admin-renderer.class.php:137
 msgid "https://smaily.com/help/how-to/forms-subscriptions/an-example-of-a-signup-form/"
@@ -396,7 +392,7 @@ msgid "Name"
 msgstr "Nimi"
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:188
+#: blocks/newsletter-signup/src/edit.js:185
 msgid "Name field label"
 msgstr "Nimevälja silt"
 
@@ -422,7 +418,7 @@ msgstr "Automaatvastajaid pole loodud"
 #: includes/smaily-widget.class.php:145
 #: integrations/cf7/partials/smaily-cf7-admin.php:47
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:276
+#: blocks/newsletter-signup/src/edit.js:273
 msgid "No autoresponder"
 msgstr "Automaatvastaja puudub"
 
@@ -453,7 +449,7 @@ msgid "Please authenticate Smaily credentials under Smaily Settings."
 msgstr "Palun kinnitage Smaily API kasutaja Smaily seadete alt."
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:120
+#: blocks/newsletter-signup/src/edit.js:117
 msgid "Please connect your Smaily account before adding a form!"
 msgstr "Palun ühendage oma Smaily konto enne vormi lisamist!"
 
@@ -478,7 +474,7 @@ msgid "Please select autoresponder for abandoned cart automation."
 msgstr "Palun vali hüljatud ostukorvi automaatvastaja."
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:118
+#: blocks/newsletter-signup/src/edit.js:115
 msgid "Plugin setup is not complete!"
 msgstr "Pistikprogrammi seadistamine pole lõpule viidud!"
 
@@ -668,7 +664,7 @@ msgid "Subscribe"
 msgstr "Liitu"
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:205
+#: blocks/newsletter-signup/src/edit.js:202
 msgid "Subscribe button label"
 msgstr "Liitumisnupu silt"
 
@@ -691,13 +687,13 @@ msgid "Subscribing failed with unknown reason."
 msgstr "Uudiskirjaga liitumine ebaõnnestus teadmata põhjusel."
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:235
+#: blocks/newsletter-signup/src/edit.js:232
 msgid "Success message"
 msgstr "Õnnestumise teade"
 
 #: includes/smaily-widget.class.php:134
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:254
+#: blocks/newsletter-signup/src/edit.js:251
 msgid "Success URL"
 msgstr "Õnnestumise URL"
 
@@ -746,7 +742,7 @@ msgid "Use the Smaily subscription form widget."
 msgstr "Kasutada Smaily uudiskirjaga liitumise vidinat."
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:175
+#: blocks/newsletter-signup/src/edit.js:172
 msgid "Visible fields"
 msgstr "Nähtavad väljad"
 
@@ -833,4 +829,8 @@ msgstr ""
 #. Plugin URI of the plugin
 #: smaily-connect.php
 msgid "https://github.com/sendsmaily/smaily-wordpress-plugin"
+msgstr ""
+
+#: admin/smaily-admin-renderer.class.php:114
+msgid "https://smaily.com/help/how-to/ecommerce-integrations/smaily-connect"
 msgstr ""

--- a/languages/smaily-connect-et.po
+++ b/languages/smaily-connect-et.po
@@ -329,7 +329,7 @@ msgid "How to create API credentials?"
 msgstr "Kuidas luua API ligipääsu?"
 
 #. Author URI of the plugin
-#: smaily-wp-connect.php
+#: smaily-connect.php
 msgid "https://smaily.com"
 msgstr "https://smaily.com"
 
@@ -554,7 +554,7 @@ msgid "Send Abandoned Cart reminder emails to store customers."
 msgstr "Saatke klientidele Hüljatud Ostukorvi meeldetuletusmeile."
 
 #. Author of the plugin
-#: smaily-wp-connect.php
+#: smaily-connect.php
 msgid "Sendsmaily LLC"
 msgstr "Sendsmaily OÜ"
 
@@ -621,7 +621,7 @@ msgid "Smaily integration is active on this site."
 msgstr "Smaily integratsioon on sellel lehel aktiivne."
 
 #. Description of the plugin
-#: smaily-wp-connect.php
+#: smaily-connect.php
 msgid "Smaily integration plugin that includes WooCommerce and Contact Form 7 integrations."
 msgstr "Smaily pistikmoodul, mis sisaldab WooCommerce'i ja Contact Form 7 integratsioone."
 
@@ -825,12 +825,12 @@ msgid "form"
 msgstr ""
 
 #. Plugin Name of the plugin
-#: smaily-wp-connect.php
+#: smaily-connect.php
 #: integrations/cf7/service.class.php:39
 msgid "Smaily WP Connect"
 msgstr ""
 
 #. Plugin URI of the plugin
-#: smaily-wp-connect.php
+#: smaily-connect.php
 msgid "https://github.com/sendsmaily/smaily-wordpress-plugin"
 msgstr ""

--- a/languages/smaily-connect-et.po
+++ b/languages/smaily-connect-et.po
@@ -827,7 +827,7 @@ msgstr ""
 #. Plugin Name of the plugin
 #: smaily-connect.php
 #: integrations/cf7/service.class.php:39
-msgid "Smaily WP Connect"
+msgid "Smaily Connect"
 msgstr ""
 
 #. Plugin URI of the plugin

--- a/languages/smaily-connect.pot
+++ b/languages/smaily-connect.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GPL-3.0+.
 msgid ""
 msgstr ""
-"Project-Id-Version: Smaily WP Connect 1.0.0\n"
+"Project-Id-Version: Smaily Connect 1.0.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/smaily-connect\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 #. Plugin Name of the plugin
 #: smaily-connect.php
 #: integrations/cf7/service.class.php:39
-msgid "Smaily WP Connect"
+msgid "Smaily Connect"
 msgstr ""
 
 #. Plugin URI of the plugin

--- a/languages/smaily-connect.pot
+++ b/languages/smaily-connect.pot
@@ -3,13 +3,13 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Smaily Connect 1.0.0\n"
-"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/smaily-connect\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/smaily-wordpress-plugin\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-03-26T10:30:26+00:00\n"
+"POT-Creation-Date: 2025-04-21T10:57:01+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.11.0\n"
 "X-Domain: smaily-connect\n"
@@ -207,7 +207,7 @@ msgid "read the detailed guide"
 msgstr ""
 
 #: admin/smaily-admin-renderer.class.php:114
-msgid "https://smaily.com/help/how-to/ecommerce-integrations/smaily-plugin-for-wordpress#toc-heading-4"
+msgid "https://smaily.com/help/how-to/ecommerce-integrations/smaily-connect"
 msgstr ""
 
 #. translators: 1: link to setting up block component guide
@@ -554,19 +554,19 @@ msgstr ""
 
 #: includes/smaily-widget.class.php:131
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:177
+#: blocks/newsletter-signup/src/edit.js:174
 msgid "Display name field"
 msgstr ""
 
 #: includes/smaily-widget.class.php:134
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:254
+#: blocks/newsletter-signup/src/edit.js:251
 msgid "Success URL"
 msgstr ""
 
 #: includes/smaily-widget.class.php:138
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:261
+#: blocks/newsletter-signup/src/edit.js:258
 msgid "Failure URL"
 msgstr ""
 
@@ -581,7 +581,7 @@ msgstr ""
 #: includes/smaily-widget.class.php:145
 #: integrations/cf7/partials/smaily-cf7-admin.php:47
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:276
+#: blocks/newsletter-signup/src/edit.js:273
 msgid "No autoresponder"
 msgstr ""
 
@@ -607,7 +607,7 @@ msgstr ""
 
 #: integrations/cf7/partials/smaily-cf7-admin.php:42
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:268
+#: blocks/newsletter-signup/src/edit.js:265
 msgid "Autoresponder"
 msgstr ""
 
@@ -708,68 +708,68 @@ msgid "newsletter"
 msgstr ""
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:112
+#: blocks/newsletter-signup/src/edit.js:109
 msgid "Go to plugin settings"
 msgstr ""
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:118
+#: blocks/newsletter-signup/src/edit.js:115
 msgid "Plugin setup is not complete!"
 msgstr ""
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:120
+#: blocks/newsletter-signup/src/edit.js:117
 msgid "Please connect your Smaily account before adding a form!"
 msgstr ""
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:175
+#: blocks/newsletter-signup/src/edit.js:172
 msgid "Visible fields"
 msgstr ""
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:188
+#: blocks/newsletter-signup/src/edit.js:185
 msgid "Name field label"
 msgstr ""
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:197
+#: blocks/newsletter-signup/src/edit.js:194
 msgid "Email field label"
 msgstr ""
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:205
+#: blocks/newsletter-signup/src/edit.js:202
 msgid "Subscribe button label"
 msgstr ""
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:213
+#: blocks/newsletter-signup/src/edit.js:210
 msgid "Full width subscribe button"
 msgstr ""
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:225
+#: blocks/newsletter-signup/src/edit.js:222
 msgid "Button border radius"
 msgstr ""
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:235
+#: blocks/newsletter-signup/src/edit.js:232
 msgid "Success message"
 msgstr ""
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:243
+#: blocks/newsletter-signup/src/edit.js:240
 msgid "Error message"
 msgstr ""
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:250
+#: blocks/newsletter-signup/src/edit.js:247
 msgid "Hidden fields"
 msgstr ""
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:258
-#: blocks/newsletter-signup/src/edit.js:265
+#: blocks/newsletter-signup/src/edit.js:255
+#: blocks/newsletter-signup/src/edit.js:262
 msgid "Defaults to current page URL."
 msgstr ""
 

--- a/languages/smaily-connect.pot
+++ b/languages/smaily-connect.pot
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Smaily WP Connect 1.0.0\n"
-"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/smaily-wp-connect\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/smaily-connect\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
@@ -12,31 +12,31 @@ msgstr ""
 "POT-Creation-Date: 2025-03-26T10:30:26+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.11.0\n"
-"X-Domain: smaily-wp-connect\n"
+"X-Domain: smaily-connect\n"
 
 #. Plugin Name of the plugin
-#: smaily-wp-connect.php
+#: smaily-connect.php
 #: integrations/cf7/service.class.php:39
 msgid "Smaily WP Connect"
 msgstr ""
 
 #. Plugin URI of the plugin
-#: smaily-wp-connect.php
+#: smaily-connect.php
 msgid "https://github.com/sendsmaily/smaily-wordpress-plugin"
 msgstr ""
 
 #. Description of the plugin
-#: smaily-wp-connect.php
+#: smaily-connect.php
 msgid "Smaily integration plugin that includes WooCommerce and Contact Form 7 integrations."
 msgstr ""
 
 #. Author of the plugin
-#: smaily-wp-connect.php
+#: smaily-connect.php
 msgid "Sendsmaily LLC"
 msgstr ""
 
 #. Author URI of the plugin
-#: smaily-wp-connect.php
+#: smaily-connect.php
 msgid "https://smaily.com"
 msgstr ""
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -34,7 +34,7 @@
     <rule ref="WordPress.WP.I18n">
         <properties>
             <property name="text_domain" type="array">
-                <element value="smaily-wp-connect" />
+                <element value="smaily-connect" />
             </property>
         </properties>
     </rule>

--- a/public/partials/smaily-public-basic.php
+++ b/public/partials/smaily-public-basic.php
@@ -4,11 +4,11 @@ defined( 'ABSPATH' ) || exit;
 
 $code             = isset( $_GET['code'] ) ? intval( $_GET['code'] ) : null;
 $messages         = array(
-	101 => __( 'Thank you for subscribing to our newsletter.', 'smaily-wp-connect' ),
-	201 => __( 'Form was not submitted using POST method.', 'smaily-wp-connect' ),
-	204 => __( 'Input does not contain a recognizable email address.', 'smaily-wp-connect' ),
+	101 => __( 'Thank you for subscribing to our newsletter.', 'smaily-connect' ),
+	201 => __( 'Form was not submitted using POST method.', 'smaily-connect' ),
+	204 => __( 'Input does not contain a recognizable email address.', 'smaily-connect' ),
 );
-$response_message = isset( $messages[ $code ] ) ? $messages[ $code ] : __( 'Subscribing failed with unknown reason.', 'smaily-wp-connect' );
+$response_message = isset( $messages[ $code ] ) ? $messages[ $code ] : __( 'Subscribing failed with unknown reason.', 'smaily-connect' );
 $is_success       = $code === 101;
 $is_error         = $code !== null && ! $is_success;
 
@@ -29,21 +29,21 @@ $is_error         = $code !== null && ! $is_success;
 	<input type="hidden" name="success_url" value="<?php echo esc_url( $parameters['success_url'] ); ?>" />
 	<input type="hidden" name="failure_url" value="<?php echo esc_url( $parameters['failure_url'] ); ?>" />
 	<p>
-		<input type="text" name="email" value="" placeholder="<?php echo esc_html__( 'Email', 'smaily-wp-connect' ); ?>" required />
+		<input type="text" name="email" value="" placeholder="<?php echo esc_html__( 'Email', 'smaily-connect' ); ?>" required />
 	</p>
 	<?php if ( $parameters['show_name'] ) : ?>
 		<p>
-			<input type="text" name="name" value="" placeholder="<?php echo esc_html__( 'Name', 'smaily-wp-connect' ); ?>" />
+			<input type="text" name="name" value="" placeholder="<?php echo esc_html__( 'Name', 'smaily-connect' ); ?>" />
 		</p>
 	<?php endif; ?>
 	<p>
 		<button type="submit">
-			<?php echo esc_html__( 'Subscribe', 'smaily-wp-connect' ); ?>
+			<?php echo esc_html__( 'Subscribe', 'smaily-connect' ); ?>
 		</button>
 	</p>
 </form>
 <?php else : ?>
 <p class="error">
-	<?php echo esc_html__( 'Smaily credentials not validated. Subscription form will not work!', 'smaily-wp-connect' ); ?>
+	<?php echo esc_html__( 'Smaily credentials not validated. Subscription form will not work!', 'smaily-connect' ); ?>
 </p>
 <?php endif; ?>

--- a/public/smaily-public.class.php
+++ b/public/smaily-public.class.php
@@ -74,7 +74,7 @@ class Public_Base {
 		// Allow overriding the template.
 		$template_path = locate_template( 'smaily/smaily-public-basic.php' );
 		if ( ! $template_path ) {
-			$template_path = SMAILY_WP_CONNECT_PLUGIN_PATH . 'public/partials/smaily-public-basic.php';
+			$template_path = SMAILY_CONNECT_PLUGIN_PATH . 'public/partials/smaily-public-basic.php';
 		}
 
 		$shortcode_attrs = shortcode_atts(

--- a/public/smaily-public.class.php
+++ b/public/smaily-public.class.php
@@ -62,7 +62,7 @@ class Public_Base {
 	 *
 	 */
 	public function add_shortcodes() {
-		add_shortcode( 'smaily_wp_connect_newsletter_form', array( $this, 'smaily_shortcode_render' ) );
+		add_shortcode( 'smaily_connect_newsletter_form', array( $this, 'smaily_shortcode_render' ) );
 	}
 
 	/**

--- a/public/smaily-public.class.php
+++ b/public/smaily-public.class.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Smaily_WP_Connect;
+namespace Smaily_Connect;
 
 use Exception;
-use Smaily_WP_Connect\Includes\Helper;
-use Smaily_WP_Connect\Includes\Options;
+use Smaily_Connect\Includes\Helper;
+use Smaily_Connect\Includes\Options;
 
 class Public_Base {
 	/**

--- a/public/template/smaily-rss-feed.php
+++ b/public/template/smaily-rss-feed.php
@@ -1,6 +1,6 @@
 <?php
 
-use Smaily_WP_Connect\Integrations\WooCommerce\Rss;
+use Smaily_Connect\Integrations\WooCommerce\Rss;
 
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {

--- a/readme.md
+++ b/readme.md
@@ -1,14 +1,14 @@
-# Smaily WP Connect
+# Smaily Connect
 
 The Smaily plugin integrates Contact Form 7 and WooCommerce, offering a complete email marketing and automation solution.
 
 ## Description
 
-**Smaily WP Connect – The Only Email Marketing Plugin You Need!**
+**Smaily Connect – The Only Email Marketing Plugin You Need!**
 
 Transform your **WordPress website, WooCommerce store, and Contact Form 7** into an **email marketing powerhouse** with Smaily – the all-in-one plugin designed to **automate your marketing, grow your audience, and drive more sales effortlessly**.
 
-**Why Smaily WP Connect?**
+**Why Smaily Connect?**
 
 **Turn Visitors into Subscribers** – Capture leads from **every touchpoint** – your website, WooCommerce store, and contact forms – all in one seamless flow.
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: sendsmaily, kaarel
 Tags: smaily, newsletter, email, mail, marketing
 Requires PHP: 7.0
 Requires at least: 6.0
-Tested up to: 6.7
+Tested up to: 6.8
 WC tested up to: 9.6.1
 Stable tag: 1.0.0
 License: GPLv3 or later

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Smaily WP Connect ===
+=== Smaily Connect ===
 Contributors: sendsmaily, kaarel
 Tags: smaily, newsletter, email, mail, marketing
 Requires PHP: 7.0
@@ -8,15 +8,15 @@ WC tested up to: 9.6.1
 Stable tag: 1.0.0
 License: GPLv3 or later
 
-The Smaily WP Connect plugin integrates Contact Form 7 and WooCommerce, offering a complete email marketing and automation solution.
+The Smaily Connect plugin integrates Contact Form 7 and WooCommerce, offering a complete email marketing and automation solution.
 
 == Description ==
 
-**Smaily WP Connect – The Only Email Marketing Plugin You Need!**
+**Smaily Connect – The Only Email Marketing Plugin You Need!**
 
 Transform your **WordPress website, WooCommerce store, and Contact Form 7** into an **email marketing powerhouse** with Smaily – the all-in-one plugin designed to **automate your marketing, grow your audience, and drive more sales effortlessly**.
 
-**Why Smaily WP Connect?**
+**Why Smaily Connect?**
 
 **Turn Visitors into Subscribers** – Capture leads from **every touchpoint** – your website, WooCommerce store, and contact forms – all in one seamless flow.
 

--- a/smaily-connect.php
+++ b/smaily-connect.php
@@ -59,6 +59,6 @@ require_once SMAILY_CONNECT_PLUGIN_PATH . 'includes/smaily.class.php';
  * Begins execution of the plugin.
  *
  */
-if ( class_exists( 'Smaily_WP_Connect' ) ) {
-	new Smaily_WP_Connect( SMAILY_CONNECT_PLUGIN_NAME, SMAILY_CONNECT_PLUGIN_VERSION );
+if ( class_exists( 'Smaily_Connect' ) ) {
+	new Smaily_Connect( SMAILY_CONNECT_PLUGIN_NAME, SMAILY_CONNECT_PLUGIN_VERSION );
 }

--- a/smaily-connect.php
+++ b/smaily-connect.php
@@ -6,7 +6,7 @@
  * Domain Path:       /languages
  * License URI:       https://www.gnu.org/licenses/gpl-3.0.en.html
  * License:           GPL-3.0+
- * Plugin Name:       Smaily WP Connect
+ * Plugin Name:       Smaily Connect
  * Plugin URI:        https://github.com/sendsmaily/smaily-wordpress-plugin
  * Text Domain:       smaily-connect
  * Version:           1.0.0
@@ -20,27 +20,27 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Current plugin version.
  */
-define( 'SMAILY_WP_CONNECT_PLUGIN_VERSION', '1.0.0' );
+define( 'SMAILY_CONNECT_PLUGIN_VERSION', '1.0.0' );
 
 /**
  * The name of the plugin.
  */
-define( 'SMAILY_WP_CONNECT_PLUGIN_NAME', 'smaily-connect' );
+define( 'SMAILY_CONNECT_PLUGIN_NAME', 'smaily-connect' );
 
 /**
  * Absolute URL to the Smaily plugin directory.
  */
-define( 'SMAILY_WP_CONNECT_PLUGIN_URL', plugins_url( '', __FILE__ ) );
+define( 'SMAILY_CONNECT_PLUGIN_URL', plugins_url( '', __FILE__ ) );
 
 /**
  * Absolute path to the Smaily plugin directory.
  */
-define( 'SMAILY_WP_CONNECT_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
+define( 'SMAILY_CONNECT_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 
 /**
  * Absolute path to the core plugin file.
  */
-define( 'SMAILY_WP_CONNECT_PLUGIN_FILE', __FILE__ );
+define( 'SMAILY_CONNECT_PLUGIN_FILE', __FILE__ );
 
 // Required to use functions is_plugin_active and deactivate_plugins.
 require_once ABSPATH . 'wp-admin/includes/plugin.php';
@@ -48,17 +48,17 @@ require_once ABSPATH . 'wp-admin/includes/plugin.php';
 /**
  * The plugin lifecycle.
  */
-require_once SMAILY_WP_CONNECT_PLUGIN_PATH . 'includes/smaily-lifecycle.class.php';
+require_once SMAILY_CONNECT_PLUGIN_PATH . 'includes/smaily-lifecycle.class.php';
 
 /**
  * The core plugin class.
  */
-require_once SMAILY_WP_CONNECT_PLUGIN_PATH . 'includes/smaily.class.php';
+require_once SMAILY_CONNECT_PLUGIN_PATH . 'includes/smaily.class.php';
 
 /**
  * Begins execution of the plugin.
  *
  */
 if ( class_exists( 'Smaily_WP_Connect' ) ) {
-	new Smaily_WP_Connect( SMAILY_WP_CONNECT_PLUGIN_NAME, SMAILY_WP_CONNECT_PLUGIN_VERSION );
+	new Smaily_WP_Connect( SMAILY_CONNECT_PLUGIN_NAME, SMAILY_CONNECT_PLUGIN_VERSION );
 }

--- a/smaily-wp-connect.php
+++ b/smaily-wp-connect.php
@@ -8,7 +8,7 @@
  * License:           GPL-3.0+
  * Plugin Name:       Smaily WP Connect
  * Plugin URI:        https://github.com/sendsmaily/smaily-wordpress-plugin
- * Text Domain:       smaily-wp-connect
+ * Text Domain:       smaily-connect
  * Version:           1.0.0
 */
 
@@ -25,7 +25,7 @@ define( 'SMAILY_WP_CONNECT_PLUGIN_VERSION', '1.0.0' );
 /**
  * The name of the plugin.
  */
-define( 'SMAILY_WP_CONNECT_PLUGIN_NAME', 'smaily-wp-connect' );
+define( 'SMAILY_WP_CONNECT_PLUGIN_NAME', 'smaily-connect' );
 
 /**
  * Absolute URL to the Smaily plugin directory.


### PR DESCRIPTION
Usage of WP has been discouraged, probably due to the WP drama. This means we can no longer use WP in our plugin name. 