### PR TITLE
fix: Fixes abandoned cart emails not being sent

### DIFF
--- a/integrations/woocommerce/cart.class.php
+++ b/integrations/woocommerce/cart.class.php
@@ -123,7 +123,7 @@ class Cart {
 		// Get row with user id.
 		$row = $wpdb->get_row(
 			$wpdb->prepare(
-				'SELECT * FROM `%1$s` WHERE customer_id=%d',
+				'SELECT * FROM `%1$s` WHERE customer_id = %2$d',
 				$wpdb->prefix . self::ABANDONED_CART_TABLE_NAME,
 				$customer_id
 			),

--- a/integrations/woocommerce/cart.class.php
+++ b/integrations/woocommerce/cart.class.php
@@ -123,7 +123,7 @@ class Cart {
 		// Get row with user id.
 		$row = $wpdb->get_row(
 			$wpdb->prepare(
-				'SELECT * FROM `%1$s` WHERE customer_id = %2$d',
+				'SELECT * FROM `%1$s` WHERE customer_id = \'%2$d\'',
 				$wpdb->prefix . self::ABANDONED_CART_TABLE_NAME,
 				$customer_id
 			),

--- a/integrations/woocommerce/cron.class.php
+++ b/integrations/woocommerce/cron.class.php
@@ -263,7 +263,7 @@ class Cron {
 		global $wpdb;
 		return $wpdb->get_results(
 			$wpdb->prepare(
-				'SELECT * FROM `%1$s` WHERE cart_status=%s AND mail_sent IS NULL',
+				'SELECT * FROM `%1$s` WHERE cart_status = \'%2$s\' AND mail_sent IS NULL',
 				$wpdb->prefix . Cart::ABANDONED_CART_TABLE_NAME,
 				'abandoned'
 			),
@@ -293,7 +293,7 @@ class Cron {
 			// Select all carts before cutoff time.
 			$carts = $wpdb->get_results(
 				$wpdb->prepare(
-					'SELECT * FROM `%1$s` WHERE cart_status=%s AND mail_sent IS NULL AND cart_updated < %s',
+					'SELECT * FROM `%1$s` WHERE cart_status = \'%2$s\' AND mail_sent IS NULL AND cart_updated < \'%3$s\'',
 					$table,
 					'open',
 					$time

--- a/readme.md
+++ b/readme.md
@@ -141,6 +141,10 @@ The following attributes are available:
 
 ## Changelog
 
+## 1.2.1
+
+- Fixed a bug where abandoned cart reminder emails were not sent due to a syntax error in the query statement building process.
+
 ## 1.2.0
 
 - Added a new block component for embedding Smaily Landing Pages.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires PHP: 7.0
 Requires at least: 6.0
 Tested up to: 6.8
 WC tested up to: 9.6.1
-Stable tag: 1.2.0
+Stable tag: 1.2.1
 License: GPLv3 or later
 
 The Smaily Connect plugin integrates Contact Form 7 and WooCommerce, offering a complete email marketing and automation solution.
@@ -59,6 +59,10 @@ Contribute to the development via [GitHub](https://github.com/sendsmaily/smaily-
 2. Activate the plugin through the 'Plugins' screen in WordPress.
 
 == Changelog ==
+
+= 1.2.1 =
+
+Fixed a bug where abandoned cart reminder emails were not sent due to a syntax error in the query statement building process.
 
 = 1.2.0 =
 

--- a/smaily-connect.php
+++ b/smaily-connect.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Smaily Connect
  * Plugin URI:        https://smaily.com/help/user-manual/smaily-connect-for-wordpress/
  * Text Domain:       smaily-connect
- * Version:           1.2.0
+ * Version:           1.2.1
 */
 
 // Exit if accessed directly.
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Current plugin version.
  */
-define( 'SMAILY_CONNECT_PLUGIN_VERSION', '1.2.0' );
+define( 'SMAILY_CONNECT_PLUGIN_VERSION', '1.2.1' );
 
 /**
  * The name of the plugin.


### PR DESCRIPTION
Fixes an issue where values were not correctly replaced in sql statements that used numbered formatter strings and not numbered formatted strings. This caused where condition to always target customer id 0 account.