### PR TITLE
Fix: Remove random ordering of RSS feed items

### DIFF
--- a/admin/js/smaily-admin.js
+++ b/admin/js/smaily-admin.js
@@ -21,7 +21,7 @@
 			}
 
 			var rss_order = $('#smaily-rss-sort-order').val()
-			if (rss_order_by != 'none' && rss_order_by != 'rand') {
+			if (rss_order_by != 'none') {
 				rss_url.searchParams.set('order', rss_order);
 			}
 

--- a/admin/smaily-admin-settings.class.php
+++ b/admin/smaily-admin-settings.class.php
@@ -427,7 +427,6 @@ class Settings {
 					'date'     => __( 'Created At', 'smaily-connect' ),
 					'id'       => __( 'ID', 'smaily-connect' ),
 					'name'     => __( 'Name', 'smaily-connect' ),
-					'rand'     => __( 'Random', 'smaily-connect' ),
 					'type'     => __( 'Type', 'smaily-connect' ),
 				),
 				'class'       => 'smaily-rss-options',

--- a/integrations/woocommerce/rss.class.php
+++ b/integrations/woocommerce/rss.class.php
@@ -46,7 +46,7 @@ class Rss {
 		if ( isset( $rss_order_by ) && $rss_order_by !== 'none' ) {
 			$parameters['order_by'] = $rss_order_by;
 		}
-		if ( isset( $rss_order ) && $rss_order_by !== 'none' && $rss_order_by !== 'rand' ) {
+		if ( isset( $rss_order ) && $rss_order_by !== 'none' ) {
 			$parameters['order'] = $rss_order;
 		}
 

--- a/languages/smaily-connect-et.po
+++ b/languages/smaily-connect-et.po
@@ -71,7 +71,7 @@ msgstr "API parool"
 msgid "API Username"
 msgstr "API kasutajanimi"
 
-#: admin/smaily-admin-settings.class.php:447
+#: admin/smaily-admin-settings.class.php:446
 msgid "Ascending"
 msgstr "Kasvavalt"
 
@@ -82,7 +82,7 @@ msgstr "Sünkroniseerige uudiskirjaga liitujaid automaatselt kasutades igapäeva
 #: integrations/cf7/partials/smaily-cf7-admin.php:42
 #: integrations/elementor/newsletter-widget.class.php:454
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:265
+#: blocks/newsletter-signup/src/edit.js:290
 msgid "Autoresponder"
 msgstr "Automaatvastaja"
 
@@ -166,7 +166,7 @@ msgid "Button"
 msgstr "Nupp"
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:222
+#: blocks/newsletter-signup/src/edit.js:235
 msgid "Button border radius"
 msgstr "Nupu piirjoone raadius"
 
@@ -217,7 +217,7 @@ msgid "Copy"
 msgstr "Kopeeri"
 
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:189
+#: blocks/landingpage/src/edit.js:195
 msgid "Copy the URL of the landing page you want to display in this block and paste it in the Block settings."
 msgstr "Kopeerige selle maandumislehe URL, mida soovite selles plokis kuvada, ja kleepige see ploki seadistustesse."
 
@@ -234,7 +234,7 @@ msgid "Created At"
 msgstr "Loodud"
 
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:204
+#: blocks/landingpage/src/edit.js:210
 msgid "creating a landing page"
 msgstr "maandumislehe loomine"
 
@@ -277,12 +277,12 @@ msgid "Dashed"
 msgstr "Katkendlik"
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:255
-#: blocks/newsletter-signup/src/edit.js:262
+#: blocks/newsletter-signup/src/edit.js:272
+#: blocks/newsletter-signup/src/edit.js:284
 msgid "Defaults to current page URL."
 msgstr "Vaikimisi praeguse lehekülje URL."
 
-#: admin/smaily-admin-settings.class.php:448
+#: admin/smaily-admin-settings.class.php:447
 msgid "Descending"
 msgstr "Kahanevalt"
 
@@ -292,7 +292,7 @@ msgstr "Ühenda lahti"
 
 #: includes/smaily-widget.class.php:131
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:174
+#: blocks/newsletter-signup/src/edit.js:181
 msgid "Display name field"
 msgstr "Kuva nime väli"
 
@@ -320,7 +320,7 @@ msgstr "Kahekordne"
 #: blocks/landingpage/build/index.js:1
 #: blocks/landingpage/src/index.js:38
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/index.js:35
+#: blocks/newsletter-signup/src/index.js:36
 msgid "email"
 msgstr "email"
 
@@ -332,7 +332,7 @@ msgid "Email"
 msgstr "E-post"
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:194
+#: blocks/newsletter-signup/src/edit.js:201
 msgid "Email field label"
 msgstr "E-posti välja silt"
 
@@ -394,7 +394,7 @@ msgid "Enter success URL"
 msgstr "Sisestage õnnestumise URL"
 
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:93
+#: blocks/landingpage/src/edit.js:96
 msgid "Enter the URL of the landing page you want to display."
 msgstr "Sisestage maandumislehe URL mida soovite kuvada."
 
@@ -411,7 +411,7 @@ msgid "Enter your name"
 msgstr "Sisestage oma nimi"
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:240
+#: blocks/newsletter-signup/src/edit.js:253
 msgid "Error message"
 msgstr "Veateade"
 
@@ -426,7 +426,7 @@ msgstr "Veateated"
 #: includes/smaily-widget.class.php:138
 #: integrations/elementor/newsletter-widget.class.php:479
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:258
+#: blocks/newsletter-signup/src/edit.js:278
 msgid "Failure URL"
 msgstr "Tõrke URL"
 
@@ -468,7 +468,7 @@ msgid "Form was not submitted using POST method."
 msgstr "Vormi ei saadetud POST meetodit kasutades."
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:210
+#: blocks/newsletter-signup/src/edit.js:220
 msgid "Full width subscribe button"
 msgstr "Täislaiuses liitumisnupp"
 
@@ -486,7 +486,7 @@ msgid "Getting started"
 msgstr "Alustamine"
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:109
+#: blocks/newsletter-signup/src/edit.js:112
 msgid "Go to plugin settings"
 msgstr "Minge pistikprogrammi seadetesse"
 
@@ -503,7 +503,7 @@ msgstr "Süvistatud"
 #: integrations/elementor/newsletter-widget.class.php:727
 #: integrations/elementor/newsletter-widget.class.php:984
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:127
+#: blocks/landingpage/src/edit.js:133
 msgid "Height"
 msgstr "Kõrgus"
 
@@ -512,7 +512,7 @@ msgid "here"
 msgstr "siin"
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:247
+#: blocks/newsletter-signup/src/edit.js:262
 msgid "Hidden fields"
 msgstr "Peidetud väljad"
 
@@ -565,7 +565,7 @@ msgid "ID"
 msgstr "ID"
 
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:195
+#: blocks/landingpage/src/edit.js:201
 msgid "If you need any help setting up the landing page, follow our awesome guide:"
 msgstr "Kui vajate abi maandumislehe loomisel, järgige meie vingeid juhiseid:"
 
@@ -590,12 +590,12 @@ msgid "Invalid data submitted."
 msgstr "Sisestatud andmed on vigased."
 
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:104
+#: blocks/landingpage/src/edit.js:110
 msgid "Invalid landing page URL!"
 msgstr "Vigane maandumislehe URL!"
 
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:215
+#: blocks/landingpage/src/edit.js:221
 msgid "Invalid Landing Page URL!"
 msgstr "Vigane maandumislehe URL!"
 
@@ -609,7 +609,7 @@ msgid "landing page"
 msgstr "maandumisleht"
 
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:99
+#: blocks/landingpage/src/edit.js:102
 msgid "Landing page URL"
 msgstr "Maandumislehe URL"
 
@@ -653,7 +653,7 @@ msgid "Name"
 msgstr "Nimi"
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:185
+#: blocks/newsletter-signup/src/edit.js:192
 msgid "Name field label"
 msgstr "Nimevälja silt"
 
@@ -666,7 +666,7 @@ msgid "Name Placeholder"
 msgstr "Nime Kohatäitja"
 
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:118
+#: blocks/landingpage/src/edit.js:124
 msgid "Need a custom thank you page?"
 msgstr "Soovite kujundada tänulehte?"
 
@@ -676,7 +676,7 @@ msgstr "Soovite kujundada tänulehte?"
 #: blocks/landingpage/build/index.js:1
 #: blocks/landingpage/src/index.js:39
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/index.js:35
+#: blocks/newsletter-signup/src/index.js:37
 msgid "newsletter"
 msgstr "uudiskiri"
 
@@ -700,7 +700,7 @@ msgstr "Automaatvastajaid pole loodud"
 #: integrations/cf7/partials/smaily-cf7-admin.php:47
 #: integrations/elementor/newsletter-widget.class.php:326
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:273
+#: blocks/newsletter-signup/src/edit.js:298
 msgid "No autoresponder"
 msgstr "Automaatvastaja puudub"
 
@@ -729,7 +729,7 @@ msgstr "Märkus.: URL-id on valikulised. Kui see jäetakse tühjaks, kasutatakse
 msgid "Opt-in subscribers directly to Smaily for seamless email marketing."
 msgstr "Lisa uudiskirjaga liitujad otse Smaily'sse sujuvaks e-posti turunduseks."
 
-#: admin/smaily-admin-settings.class.php:440
+#: admin/smaily-admin-settings.class.php:439
 msgid "Order by"
 msgstr "Sorteeri"
 
@@ -755,7 +755,7 @@ msgid "Please authenticate Smaily credentials under Smaily Settings."
 msgstr "Palun kinnitage Smaily API kasutaja Smaily seadete alt."
 
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:217
+#: blocks/landingpage/src/edit.js:223
 msgid "Please check the entered URL. It is invalid!"
 msgstr "Palun kontrollige sisestatud URL-i. See on vigane!"
 
@@ -770,7 +770,7 @@ msgid "Please configure the Smaily Connect plugin settings first."
 msgstr "Palun seadistage esmalt Smaily Connect plugin."
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:117
+#: blocks/newsletter-signup/src/edit.js:122
 msgid "Please connect your Smaily account before adding a form!"
 msgstr "Palun ühendage oma Smaily konto enne vormi lisamist!"
 
@@ -795,7 +795,7 @@ msgid "Please select autoresponder for abandoned cart automation."
 msgstr "Palun vali hüljatud ostukorvi automaatvastaja."
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:115
+#: blocks/newsletter-signup/src/edit.js:119
 msgid "Plugin setup is not complete!"
 msgstr "Pistikprogrammi seadistamine pole lõpule viidud!"
 
@@ -831,17 +831,13 @@ msgstr "Toote hind"
 msgid "Product Quantity"
 msgstr "Toote kogus"
 
-#: admin/smaily-admin-settings.class.php:457
+#: admin/smaily-admin-settings.class.php:456
 msgid "Product RSS feed"
 msgstr "Toote RSS-voog"
 
 #: admin/partials/smaily-admin-woocommerce-abandoned-cart.php:22
 msgid "Product SKU"
 msgstr "Toote SKU"
-
-#: admin/smaily-admin-settings.class.php:430
-msgid "Random"
-msgstr "Juhuslik"
 
 #: admin/partials/smaily-admin-tutorial-subscriber-collection.php:58
 #: admin/partials/smaily-admin-tutorial-subscriber-collection.php:103
@@ -878,7 +874,7 @@ msgstr "Saatke klientidele Hüljatud Ostukorvi meeldetuletusmeile."
 
 #: admin/smaily-admin.class.php:346
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:86
+#: blocks/landingpage/src/edit.js:89
 msgid "Settings"
 msgstr "Seaded"
 
@@ -941,7 +937,7 @@ msgid "Smaily Connect"
 msgstr "Smaily Connect"
 
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:187
+#: blocks/landingpage/src/edit.js:193
 msgid "Smaily Connect Landing Page"
 msgstr "Smaily Connect Maandumisleht"
 
@@ -975,8 +971,8 @@ msgid "Smaily integration with your WooCommerce store allows you to:"
 msgstr "Smaily integratsioon sinu WooCommerce'i poega võimaldab:"
 
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:77
-#: blocks/landingpage/src/edit.js:176
+#: blocks/landingpage/src/edit.js:80
+#: blocks/landingpage/src/edit.js:182
 #: blocks/landingpage/src/index.js:32
 msgid "Smaily Landing Page"
 msgstr "Smaily Maandumisleht"
@@ -1036,7 +1032,7 @@ msgid "Subscribe"
 msgstr "Liitu"
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:202
+#: blocks/newsletter-signup/src/edit.js:209
 msgid "Subscribe button label"
 msgstr "Liitumisnupu silt"
 
@@ -1059,7 +1055,7 @@ msgid "Subscribing failed with unknown reason."
 msgstr "Uudiskirjaga liitumine ebaõnnestus teadmata põhjusel."
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:232
+#: blocks/newsletter-signup/src/edit.js:245
 msgid "Success message"
 msgstr "Õnnestumise teade"
 
@@ -1074,7 +1070,7 @@ msgstr "Õnnestumise Teated"
 #: includes/smaily-widget.class.php:134
 #: integrations/elementor/newsletter-widget.class.php:466
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:251
+#: blocks/newsletter-signup/src/edit.js:266
 msgid "Success URL"
 msgstr "Õnnestumise URL"
 
@@ -1112,12 +1108,12 @@ msgstr "Pealkiri"
 msgid "Top Gap"
 msgstr "Ülemine vahe"
 
-#: admin/smaily-admin-settings.class.php:431
+#: admin/smaily-admin-settings.class.php:430
 msgid "Type"
 msgstr "Tüüp"
 
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:89
+#: blocks/landingpage/src/edit.js:92
 msgid "URL"
 msgstr "URL"
 
@@ -1150,7 +1146,7 @@ msgid "Vertical"
 msgstr "Vertikaalne"
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:172
+#: blocks/newsletter-signup/src/edit.js:179
 msgid "Visible fields"
 msgstr "Nähtavad väljad"
 
@@ -1159,7 +1155,7 @@ msgid "Visible Fields"
 msgstr "Nähtavad väljad"
 
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:139
+#: blocks/landingpage/src/edit.js:145
 msgid "Width"
 msgstr "Laius"
 

--- a/languages/smaily-connect.pot
+++ b/languages/smaily-connect.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL-3.0+.
 msgid ""
 msgstr ""
-"Project-Id-Version: Smaily Connect 1.2.0\n"
+"Project-Id-Version: Smaily Connect 1.2.2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/smaily-wordpress-plugin\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-04-30T09:05:43+00:00\n"
+"POT-Creation-Date: 2025-08-06T10:50:47+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.11.0\n"
 "X-Domain: smaily-connect\n"
@@ -453,26 +453,22 @@ msgid "Name"
 msgstr ""
 
 #: admin/smaily-admin-settings.class.php:430
-msgid "Random"
-msgstr ""
-
-#: admin/smaily-admin-settings.class.php:431
 msgid "Type"
 msgstr ""
 
-#: admin/smaily-admin-settings.class.php:440
+#: admin/smaily-admin-settings.class.php:439
 msgid "Order by"
 msgstr ""
 
-#: admin/smaily-admin-settings.class.php:447
+#: admin/smaily-admin-settings.class.php:446
 msgid "Ascending"
 msgstr ""
 
-#: admin/smaily-admin-settings.class.php:448
+#: admin/smaily-admin-settings.class.php:447
 msgid "Descending"
 msgstr ""
 
-#: admin/smaily-admin-settings.class.php:457
+#: admin/smaily-admin-settings.class.php:456
 msgid "Product RSS feed"
 msgstr ""
 
@@ -524,7 +520,7 @@ msgstr ""
 
 #: admin/smaily-admin.class.php:346
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:86
+#: blocks/landingpage/src/edit.js:89
 msgid "Settings"
 msgstr ""
 
@@ -572,21 +568,21 @@ msgstr ""
 
 #: includes/smaily-widget.class.php:131
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:174
+#: blocks/newsletter-signup/src/edit.js:181
 msgid "Display name field"
 msgstr ""
 
 #: includes/smaily-widget.class.php:134
 #: integrations/elementor/newsletter-widget.class.php:466
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:251
+#: blocks/newsletter-signup/src/edit.js:266
 msgid "Success URL"
 msgstr ""
 
 #: includes/smaily-widget.class.php:138
 #: integrations/elementor/newsletter-widget.class.php:479
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:258
+#: blocks/newsletter-signup/src/edit.js:278
 msgid "Failure URL"
 msgstr ""
 
@@ -603,7 +599,7 @@ msgstr ""
 #: integrations/cf7/partials/smaily-cf7-admin.php:47
 #: integrations/elementor/newsletter-widget.class.php:326
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:273
+#: blocks/newsletter-signup/src/edit.js:298
 msgid "No autoresponder"
 msgstr ""
 
@@ -630,7 +626,7 @@ msgstr ""
 #: integrations/cf7/partials/smaily-cf7-admin.php:42
 #: integrations/elementor/newsletter-widget.class.php:454
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:265
+#: blocks/newsletter-signup/src/edit.js:290
 msgid "Autoresponder"
 msgstr ""
 
@@ -684,7 +680,7 @@ msgstr ""
 #: blocks/landingpage/build/index.js:1
 #: blocks/landingpage/src/index.js:39
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/index.js:35
+#: blocks/newsletter-signup/src/index.js:37
 msgid "newsletter"
 msgstr ""
 
@@ -692,7 +688,7 @@ msgstr ""
 #: blocks/landingpage/build/index.js:1
 #: blocks/landingpage/src/index.js:38
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/index.js:35
+#: blocks/newsletter-signup/src/index.js:36
 msgid "email"
 msgstr ""
 
@@ -964,7 +960,7 @@ msgstr ""
 #: integrations/elementor/newsletter-widget.class.php:727
 #: integrations/elementor/newsletter-widget.class.php:984
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:127
+#: blocks/landingpage/src/edit.js:133
 msgid "Height"
 msgstr ""
 
@@ -1051,32 +1047,32 @@ msgid "checkout"
 msgstr ""
 
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:187
+#: blocks/landingpage/src/edit.js:193
 msgid "Smaily Connect Landing Page"
 msgstr ""
 
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:189
+#: blocks/landingpage/src/edit.js:195
 msgid "Copy the URL of the landing page you want to display in this block and paste it in the Block settings."
 msgstr ""
 
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:195
+#: blocks/landingpage/src/edit.js:201
 msgid "If you need any help setting up the landing page, follow our awesome guide:"
 msgstr ""
 
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:204
+#: blocks/landingpage/src/edit.js:210
 msgid "creating a landing page"
 msgstr ""
 
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:215
+#: blocks/landingpage/src/edit.js:221
 msgid "Invalid Landing Page URL!"
 msgstr ""
 
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:217
+#: blocks/landingpage/src/edit.js:223
 msgid "Please check the entered URL. It is invalid!"
 msgstr ""
 
@@ -1086,39 +1082,39 @@ msgid "Please configure the plugin first."
 msgstr ""
 
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:77
-#: blocks/landingpage/src/edit.js:176
+#: blocks/landingpage/src/edit.js:80
+#: blocks/landingpage/src/edit.js:182
 #: blocks/landingpage/src/index.js:32
 msgid "Smaily Landing Page"
 msgstr ""
 
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:89
+#: blocks/landingpage/src/edit.js:92
 msgid "URL"
 msgstr ""
 
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:93
+#: blocks/landingpage/src/edit.js:96
 msgid "Enter the URL of the landing page you want to display."
 msgstr ""
 
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:99
+#: blocks/landingpage/src/edit.js:102
 msgid "Landing page URL"
 msgstr ""
 
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:104
+#: blocks/landingpage/src/edit.js:110
 msgid "Invalid landing page URL!"
 msgstr ""
 
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:118
+#: blocks/landingpage/src/edit.js:124
 msgid "Need a custom thank you page?"
 msgstr ""
 
 #: blocks/landingpage/build/index.js:1
-#: blocks/landingpage/src/edit.js:139
+#: blocks/landingpage/src/edit.js:145
 msgid "Width"
 msgstr ""
 
@@ -1128,68 +1124,68 @@ msgid "landing page"
 msgstr ""
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:109
+#: blocks/newsletter-signup/src/edit.js:112
 msgid "Go to plugin settings"
 msgstr ""
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:115
+#: blocks/newsletter-signup/src/edit.js:119
 msgid "Plugin setup is not complete!"
 msgstr ""
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:117
+#: blocks/newsletter-signup/src/edit.js:122
 msgid "Please connect your Smaily account before adding a form!"
 msgstr ""
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:172
+#: blocks/newsletter-signup/src/edit.js:179
 msgid "Visible fields"
 msgstr ""
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:185
+#: blocks/newsletter-signup/src/edit.js:192
 msgid "Name field label"
 msgstr ""
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:194
+#: blocks/newsletter-signup/src/edit.js:201
 msgid "Email field label"
 msgstr ""
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:202
+#: blocks/newsletter-signup/src/edit.js:209
 msgid "Subscribe button label"
 msgstr ""
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:210
+#: blocks/newsletter-signup/src/edit.js:220
 msgid "Full width subscribe button"
 msgstr ""
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:222
+#: blocks/newsletter-signup/src/edit.js:235
 msgid "Button border radius"
 msgstr ""
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:232
+#: blocks/newsletter-signup/src/edit.js:245
 msgid "Success message"
 msgstr ""
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:240
+#: blocks/newsletter-signup/src/edit.js:253
 msgid "Error message"
 msgstr ""
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:247
+#: blocks/newsletter-signup/src/edit.js:262
 msgid "Hidden fields"
 msgstr ""
 
 #: blocks/newsletter-signup/build/index.js:1
-#: blocks/newsletter-signup/src/edit.js:255
-#: blocks/newsletter-signup/src/edit.js:262
+#: blocks/newsletter-signup/src/edit.js:272
+#: blocks/newsletter-signup/src/edit.js:284
 msgid "Defaults to current page URL."
 msgstr ""
 

--- a/readme.md
+++ b/readme.md
@@ -141,6 +141,10 @@ The following attributes are available:
 
 ## Changelog
 
+## 1.2.2
+
+- Fixed RSS feed product query by removing random ordering. The combination of random ordering and query limits could result in empty product feeds on subsequent requests, causing RSS parser failures.
+
 ## 1.2.1
 
 - Fixed a bug where abandoned cart reminder emails were not sent due to a syntax error in the query statement building process.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires PHP: 7.0
 Requires at least: 6.0
 Tested up to: 6.8
 WC tested up to: 9.6.1
-Stable tag: 1.2.1
+Stable tag: 1.2.2
 License: GPLv3 or later
 
 The Smaily Connect plugin integrates Contact Form 7 and WooCommerce, offering a complete email marketing and automation solution.
@@ -59,6 +59,10 @@ Contribute to the development via [GitHub](https://github.com/sendsmaily/smaily-
 2. Activate the plugin through the 'Plugins' screen in WordPress.
 
 == Changelog ==
+
+= 1.2.2 =
+
+- Fixed RSS feed product query by removing random ordering. The combination of random ordering and query limits could result in empty product feeds on subsequent requests, causing RSS parser failures.
 
 = 1.2.1 =
 

--- a/smaily-connect.php
+++ b/smaily-connect.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Smaily Connect
  * Plugin URI:        https://smaily.com/help/user-manual/smaily-connect-for-wordpress/
  * Text Domain:       smaily-connect
- * Version:           1.2.1
+ * Version:           1.2.2
 */
 
 // Exit if accessed directly.
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Current plugin version.
  */
-define( 'SMAILY_CONNECT_PLUGIN_VERSION', '1.2.1' );
+define( 'SMAILY_CONNECT_PLUGIN_VERSION', '1.2.2' );
 
 /**
  * The name of the plugin.


### PR DESCRIPTION
Removes random ordering of RSS feed items. This is a broken option as the subsequent requests to the same URL do not give out the same feed items. This causes feed item loading errors when the RSS-importer tries to load RSS-feed items. The random ordering and limit combination may cause selected items not to appear.

Random ordering is also not valid from a logical perspective, as the user has to pick the items when using the RSS-feed block in the editor. The email would not receive random items anyway, so the option is also logically invalid.