### PR TITLE
i18n: Load plugin text domain in the init hook

### DIFF
--- a/includes/smaily-lifecycle.class.php
+++ b/includes/smaily-lifecycle.class.php
@@ -32,7 +32,7 @@ class Lifecycle {
 		register_activation_hook( SMAILY_CONNECT_PLUGIN_FILE, array( $this, 'activate' ) );
 		register_deactivation_hook( SMAILY_CONNECT_PLUGIN_FILE, array( $this, 'deactivate' ) );
 		register_uninstall_hook( SMAILY_CONNECT_PLUGIN_FILE, array( __CLASS__, 'uninstall' ) );
-		add_action( 'plugins_loaded', array( $this, 'set_locale' ) );
+		add_action( 'init', array( $this, 'set_locale' ) );
 		add_action( 'plugins_loaded', array( $this, 'update' ) );
 		add_action( 'upgrader_process_complete', array( $this, 'check_for_update' ), 10, 2 );
 		add_action( 'activated_plugin', array( $this, 'check_for_dependency' ), 10, 2 );

--- a/readme.md
+++ b/readme.md
@@ -141,6 +141,10 @@ The following attributes are available:
 
 ## Changelog
 
+## 1.2.3
+
+- Load the plugin text domain in the `init` action. This complies with the WordPress 6.7+ plugin development standards and ensures that the plugin translations are loaded correctly.
+
 ## 1.2.2
 
 - Fixed RSS feed product query by removing random ordering. The combination of random ordering and query limits could result in empty product feeds on subsequent requests, causing RSS parser failures.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires PHP: 7.0
 Requires at least: 6.0
 Tested up to: 6.8
 WC tested up to: 9.6.1
-Stable tag: 1.2.2
+Stable tag: 1.2.3
 License: GPLv3 or later
 
 The Smaily Connect plugin integrates Contact Form 7 and WooCommerce, offering a complete email marketing and automation solution.
@@ -59,6 +59,10 @@ Contribute to the development via [GitHub](https://github.com/sendsmaily/smaily-
 2. Activate the plugin through the 'Plugins' screen in WordPress.
 
 == Changelog ==
+
+## 1.2.3
+
+- Load the plugin text domain in the `init` action. This complies with the WordPress 6.7+ plugin development standards and ensures that the plugin translations are loaded correctly.
 
 = 1.2.2 =
 

--- a/smaily-connect.php
+++ b/smaily-connect.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Smaily Connect
  * Plugin URI:        https://smaily.com/help/user-manual/smaily-connect-for-wordpress/
  * Text Domain:       smaily-connect
- * Version:           1.2.2
+ * Version:           1.2.3
 */
 
 // Exit if accessed directly.
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Current plugin version.
  */
-define( 'SMAILY_CONNECT_PLUGIN_VERSION', '1.2.2' );
+define( 'SMAILY_CONNECT_PLUGIN_VERSION', '1.2.3' );
 
 /**
  * The name of the plugin.


### PR DESCRIPTION
It is recommended to load translations in the `init` hook. Our plugin used an older pattern where the translation files were loaded earlier, in the `plugins_loaded` hook. We should respect the standard.