### PR TITLE
Improve credential error notices and autoresponder query

### DIFF
--- a/admin/css/smaily-admin.css
+++ b/admin/css/smaily-admin.css
@@ -5,6 +5,16 @@
   letter-spacing: 2%;
 }
 
+.smaily-connect-admin-notice {
+  background-color: #fff3f6;
+  padding: 10px 20px;
+  margin-bottom: 20px;
+}
+
+.smaily-connect-admin-notice.notice-error {
+  border-left: 4px solid #e91e63;
+}
+
 .smaily-connect-admin-settings input[type="text"],
 .smaily-connect-admin-settings input[type="password"],
 .smaily-connect-admin-settings input[type="number"],

--- a/admin/smaily-admin-renderer.class.php
+++ b/admin/smaily-admin-renderer.class.php
@@ -32,7 +32,7 @@ class Renderer {
 	public function render_connection_section_header() {
 		?>
 		<?php if ( ! $this->are_credentials_valid() ) : ?>
-			<div class="error smaily-notice is-dismissible">
+			<div class="smaily-connect-admin-notice notice-error">
 				<p>
 					<?php
 					esc_html_e(

--- a/includes/smaily-api.class.php
+++ b/includes/smaily-api.class.php
@@ -108,7 +108,7 @@ class API {
 	 * @param string $path     Endpoint URL path.
 	 * @param string $methods  Methods accepted by the endpoint.
 	 * @param string $callback Function name for the endpoint logic.
-	 * @param array $args      Extra arguments for register_rest_route.
+	 * @param array  $args      Extra arguments for register_rest_route.
 	 */
 	private function register_endpoint( $version, $path, $methods, $callback, $args = array() ) {
 		$defaults = array(

--- a/includes/smaily-helper.class.php
+++ b/includes/smaily-helper.class.php
@@ -21,16 +21,29 @@ class Helper {
 		$request = new Smaily_Client( $options );
 		$result  = $request->list_autoresponders();
 
-		if ( empty( $result['body'] ) ) {
+		if ( ! isset( $result['body'] ) || empty( $result['body'] ) ) {
 			return array();
 		}
 
 		$autoresponder_list = array();
 		foreach ( $result['body'] as $autoresponder ) {
+			if ( ! is_array( $autoresponder ) ) {
+				continue;
+			}
+
+			if ( ! isset( $autoresponder['id'] ) || ! isset( $autoresponder['title'] ) ) {
+				continue;
+			}
+
+			if ( empty( $autoresponder['id'] ) || empty( $autoresponder['title'] ) ) {
+				continue;
+			}
+
 			$id                        = $autoresponder['id'];
 			$title                     = $autoresponder['title'];
 			$autoresponder_list[ $id ] = $title;
 		}
+
 		return $autoresponder_list;
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -141,6 +141,11 @@ The following attributes are available:
 
 ## Changelog
 
+## 1.3.1
+
+- Improved the admin notice when the Smaily API credentials are invalid. Now the notice is rendered closer to the credentials input fields for better visibility.
+- Improved autoresponder listing function validation to handle edge cases and ensure robust performance.
+
 ## 1.3.0
 
 - Improved the Contact Form 7 integration by allowing user to configure each form individually.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires PHP: 7.0
 Requires at least: 6.0
 Tested up to: 6.8
 WC tested up to: 9.6.1
-Stable tag: 1.3.0
+Stable tag: 1.3.1
 License: GPLv3 or later
 
 The Smaily Connect plugin integrates Contact Form 7 and WooCommerce, offering a complete email marketing and automation solution.
@@ -59,6 +59,11 @@ Contribute to the development via [GitHub](https://github.com/sendsmaily/smaily-
 2. Activate the plugin through the 'Plugins' screen in WordPress.
 
 == Changelog ==
+
+= 1.3.1 =
+
+- Improved the admin notice when the Smaily API credentials are invalid. Now the notice is rendered closer to the credentials input fields for better visibility.
+- Improved autoresponder listing function validation to handle edge cases and ensure robust performance.
 
 = 1.3.0 =
 

--- a/smaily-connect.php
+++ b/smaily-connect.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Smaily Connect
  * Plugin URI:        https://smaily.com/help/user-manual/smaily-connect-for-wordpress/
  * Text Domain:       smaily-connect
- * Version:           1.3.0
+ * Version:           1.3.1
 */
 
 // Exit if accessed directly.
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Current plugin version.
  */
-define( 'SMAILY_CONNECT_PLUGIN_VERSION', '1.3.0' );
+define( 'SMAILY_CONNECT_PLUGIN_VERSION', '1.3.1' );
 
 /**
  * The name of the plugin.


### PR DESCRIPTION
Improves the rendering of the credentials section header notice by adjusting its styles. Previously, the CSS error class caused the notice to appear under the general admin notices, which was misleading. The notice is now correctly displayed near the related input field (credentials).

Also refines the autoresponder listing query by handling invalid values more consistently. If invalid values are found, they are now treated as if no autoresponders are available.