### PR TITLE
integrations/woocommerce: Use RFC822 time format for created_at field

### DIFF
--- a/integrations/woocommerce/rss.class.php
+++ b/integrations/woocommerce/rss.class.php
@@ -152,7 +152,7 @@ class Rss {
 				'discount'      => self::calculate_discount( floatval( $current_price ), floatval( $regular_price ) ),
 				'url'           => $url,
 				'title'         => $product->get_title(),
-				'created_at'    => $product->get_date_created()->date_i18n( 'D, d M Y H:i:s' ),
+				'created_at'    => $product->get_date_created()->format( DATE_RFC822 ),
 				'enclosure_url' => self::get_product_image_url( $product->get_id() ),
 				'description'   => do_shortcode( $product->get_description() ),
 			);

--- a/readme.md
+++ b/readme.md
@@ -141,6 +141,10 @@ The following attributes are available:
 
 ## Changelog
 
+## 1.3.2
+
+Fixed a bug where the RSS-feed `pubDate` was not correctly formatted, which could lead to issues while importing sorted products into Smaily templates. Now the `pubDate` is formatted according to the RFC 822 standard, ensuring compatibility with RSS parsers.
+
 ## 1.3.1
 
 - Improved the admin notice when the Smaily API credentials are invalid. Now the notice is rendered closer to the credentials input fields for better visibility.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires PHP: 7.0
 Requires at least: 6.0
 Tested up to: 6.8
 WC tested up to: 9.6.1
-Stable tag: 1.3.1
+Stable tag: 1.3.2
 License: GPLv3 or later
 
 The Smaily Connect plugin integrates Contact Form 7 and WooCommerce, offering a complete email marketing and automation solution.

--- a/smaily-connect.php
+++ b/smaily-connect.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Smaily Connect
  * Plugin URI:        https://smaily.com/help/user-manual/smaily-connect-for-wordpress/
  * Text Domain:       smaily-connect
- * Version:           1.3.1
+ * Version:           1.3.2
 */
 
 // Exit if accessed directly.
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Current plugin version.
  */
-define( 'SMAILY_CONNECT_PLUGIN_VERSION', '1.3.1' );
+define( 'SMAILY_CONNECT_PLUGIN_VERSION', '1.3.2' );
 
 /**
  * The name of the plugin.


### PR DESCRIPTION
The current time format is human readable, but the RSS feed is mainly used to import products into email templates. Using the RFC822 time format without translating the value allows Smaily RSS-parser to correctly parse the dates.