### PR TITLE
fix: Add correct asset path for checkout-optin block

### DIFF
--- a/blocks/checkout-optin/smaily-integration.class.php
+++ b/blocks/checkout-optin/smaily-integration.class.php
@@ -95,7 +95,7 @@ class Integration implements IntegrationInterface {
 	public function register_frontend_scripts() {
 		$script_path       = '/build/smaily-checkout-optin-block-frontend.js';
 		$script_url        = plugins_url( $script_path, __FILE__ );
-		$script_asset_path = __DIR__ . '/build/newsletter-block-frontend.asset.php';
+		$script_asset_path = __DIR__ . '/build/smaily-checkout-optin-block-frontend.asset.php';
 		$script_asset      = file_exists( $script_asset_path )
 			? require $script_asset_path
 			: array(


### PR DESCRIPTION
The current path in the build directory references newsletter-block, not optin. This PR fixes the issue of loading an invalid asset while initializing blocks