### PR TITLE
fix: Abandoned cart syning empty carts

### DIFF
--- a/integrations/woocommerce/cron.class.php
+++ b/integrations/woocommerce/cron.class.php
@@ -163,7 +163,7 @@ class Cron {
 
 		foreach ( $this->get_abandoned_carts() as $cart ) {
 			$cart_content = maybe_unserialize( $cart['cart_content'] );
-			if ( empty( $cart ) ) {
+			if ( empty( $cart_content ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
Wrong variable check caused the empty carts being sent over Smaily API. The previous value used in the logic was result of a DB query instead of the serialized cart value.