### PR TITLE
fix: User gender always defaulting to male

### DIFF
--- a/integrations/woocommerce/data-handler.class.php
+++ b/integrations/woocommerce/data-handler.class.php
@@ -90,9 +90,13 @@ class Data_Handler {
 					}
 					break;
 				case 'user_gender':
-					$gender = $meta['user_gender'][0] ?? '';
-					if ( ! empty( $gender ) ) {
-						$user_sync_data['user_gender'] = $gender === '0' ? 'Female' : 'Male';
+					$gender     = $meta['user_gender'][0] ?? '';
+					$gender_map = array(
+						'1' => 'Male',
+						'2' => 'Female',
+					);
+					if ( isset( $gender_map[ $gender ] ) ) {
+						$user_sync_data['user_gender'] = $gender_map[ $gender ];
 					}
 					break;
 				case 'site_title':


### PR DESCRIPTION
User gender check had two values - male and female. Due to different mapping of values the female option was never reached.

This PR fixes the issue by correctly mapping male and female values with their equivalent form values. Now synchronized genders reflect the user selected value.