### PR TITLE
fix: Customer synchronization using 0 time when timestamp parsing fails

### DIFF
--- a/integrations/woocommerce/data-handler.class.php
+++ b/integrations/woocommerce/data-handler.class.php
@@ -105,7 +105,10 @@ class Data_Handler {
 					// 2014-03-28 to YYYY-MM-DD format.
 					$birthday = $meta['user_dob'][0] ?? '';
 					if ( ! empty( $birthday ) ) {
-						$user_sync_data['birthday'] = gmdate( 'Y-m-d', strtotime( $birthday ) );
+						$timestamp = strtotime( $birthday );
+						if ( $timestamp !== false ) {
+							$user_sync_data['birthday'] = gmdate( 'Y-m-d', $timestamp );
+						}
 					}
 					break;
 				case 'first_name':


### PR DESCRIPTION
The current implementation sends 1970-01-01 bithday filed when timestamp parsing fails. This causes wrong dates to be synchronized with user data.

This PR changes the logic - when parsing fails the value is omitted instead of passing a 1970-s date as user birthday.