### PR TITLE
fix: User profile data not corretly saved

### DIFF
--- a/integrations/woocommerce/profile-settings.class.php
+++ b/integrations/woocommerce/profile-settings.class.php
@@ -264,8 +264,8 @@ class Profile_Settings {
 		}
 
 		if ( ! empty( $user_data ) ) {
-			$sanitized_data['ID'] = $user_id;
-			wp_update_user( $sanitized_data );
+			$user_data['ID'] = $user_id;
+			wp_update_user( $user_data );
 		}
 	}
 


### PR DESCRIPTION
The save_account_fields method used a wrong variable name causing to update user data with only the User ID.

This PR changes the logic to include the changed Smaily fields also.