### PR TITLE
maint: Update phpcs configuration

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -8,6 +8,7 @@
     <exclude-pattern>/blocks/node_modules</exclude-pattern>
 
     <arg name="cache" />
+    <arg value="ps" />
     <arg name="parallel" value="8" />
     <arg name="extensions" value="php" />
 
@@ -24,12 +25,12 @@
     <rule ref="Generic.Commenting.Todo" />
 
     <!-- Check for PHP cross-version compatibility. -->
-    <config name="testVersion" value="7.0-" />
+    <config name="testVersion" value="7.4-" />
     <rule ref="PHPCompatibilityWP">
         <include-pattern>*\.php$</include-pattern>
     </rule>
 
-    <config name="minimum_supported_wp_version" value="6.0" />
+    <config name="minimum_supported_wp_version" value="6.5" />
 
     <rule ref="WordPress.WP.I18n">
         <properties>


### PR DESCRIPTION
This PR rises the WordPress and PHP versions in phpcs configuration to reflect the new minimum versions. Also the command now logs progress output.