### PR TITLE
chore: Recover from HTTP 429 Too Many Requests error on releasing

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -77,10 +77,13 @@ if [[ ! -d $TEMP_SVN_REPO ]];
 then
     echo "Checking out WordPress.org plugin repository"
     svn checkout $SVN_REPO $TEMP_SVN_REPO --depth immediates || { echo "Unable to checkout repo."; exit 1; }
-    svn update $TEMP_SVN_REPO/assets --set-depth infinity
-    svn update $TEMP_SVN_REPO/tags/${VERSION} --set-depth infinity
-    svn update $TEMP_SVN_REPO/trunk --set-depth infinity
 fi
+
+echo "Updating WordPress.org plugin repository"
+svn cleanup $TEMP_SVN_REPO
+svn update $TEMP_SVN_REPO/assets --set-depth infinity
+svn update $TEMP_SVN_REPO/tags/${VERSION} --set-depth infinity
+svn update $TEMP_SVN_REPO/trunk --set-depth infinity
 
 # Ensure we are on version branch.
 echo "Switching to branch"


### PR DESCRIPTION
WordPress.org plugins are published to a SVN server which limits the number of overall requests made against the server, causing the plugin repository checkout to fail due to HTTP 429 Too Many Requests error.

Previously recovering from the throttling required deleting the temporary SVN repository folder and retrying checkout from the start, causing the checkout to fail at the same spot.

This change allows the checkout procedure to continue where it left of, speeding up the release process.